### PR TITLE
[FEAT] Windows MSIX 설치 스크립트 추가

### DIFF
--- a/.github/workflows/build-windows-msix.yml
+++ b/.github/workflows/build-windows-msix.yml
@@ -131,12 +131,52 @@ jobs:
           VERSION=$(grep 'version:' pubspec.yaml | head -1 | awk '{print $2}' | cut -d'+' -f1)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      # 배포 패키지 생성 (MSIX + 설치 스크립트)
+      - name: Create distribution package
+        shell: powershell
+        run: |
+          $distDir = "dist/CoTalk-Windows"
+          New-Item -ItemType Directory -Path $distDir -Force
+          
+          # MSIX 파일 복사
+          Copy-Item "build/windows/x64/runner/Release/CoTalk.msix" -Destination $distDir
+          
+          # 설치 스크립트 복사
+          Copy-Item "installer/install.ps1" -Destination $distDir
+          Copy-Item "installer/Co-Talk 설치.bat" -Destination $distDir
+          Copy-Item "installer/Co-Talk 제거.bat" -Destination $distDir
+          
+          # README 생성
+          $readme = @"
+          # Co-Talk v${{ steps.version.outputs.version }} - Windows 설치 가이드
+          
+          ## 설치 방법
+          
+          1. 'Co-Talk 설치.bat' 파일을 더블클릭하세요.
+          2. 관리자 권한 요청 창이 나타나면 '예'를 클릭하세요.
+          3. 설치가 완료되면 시작 메뉴에서 'Co-Talk'을 검색하여 실행하세요.
+          
+          ## 제거 방법
+          
+          1. 'Co-Talk 제거.bat' 파일을 더블클릭하세요.
+          2. 관리자 권한 요청 창이 나타나면 '예'를 클릭하세요.
+          
+          ## 시스템 요구사항
+          
+          - Windows 10 버전 1809 (빌드 17763) 이상
+          - x64 아키텍처
+          "@
+          $readme | Out-File -FilePath "$distDir/README.txt" -Encoding UTF8
+          
+          # ZIP 압축
+          Compress-Archive -Path "$distDir/*" -DestinationPath "dist/CoTalk-Windows-v${{ steps.version.outputs.version }}.zip"
+
       # 빌드 결과물 업로드
       - name: Upload MSIX artifact
         uses: actions/upload-artifact@v4
         with:
           name: CoTalk-Windows-v${{ steps.version.outputs.version }}
-          path: build/windows/x64/runner/Release/CoTalk.msix
+          path: dist/CoTalk-Windows-v${{ steps.version.outputs.version }}.zip
           retention-days: 30
 
   # ===========================================
@@ -160,7 +200,7 @@ jobs:
           VERSION=$(grep 'version:' pubspec.yaml | head -1 | awk '{print $2}' | cut -d'+' -f1)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Download MSIX artifact
+      - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: CoTalk-Windows-v${{ steps.version.outputs.version }}
@@ -175,12 +215,21 @@ jobs:
             ## Co-Talk Windows Desktop v${{ steps.version.outputs.version }}
 
             ### 설치 방법
-            1. `CoTalk.msix` 파일을 다운로드합니다
-            2. 더블클릭하여 설치합니다
-            3. 자체 서명 인증서 설치를 허용합니다
+            1. `CoTalk-Windows-v${{ steps.version.outputs.version }}.zip` 파일을 다운로드합니다
+            2. ZIP 파일 압축을 해제합니다
+            3. **`Co-Talk 설치.bat`** 파일을 더블클릭합니다
+            4. 관리자 권한 요청 창이 나타나면 '예'를 클릭합니다
+            5. 시작 메뉴에서 'Co-Talk'을 검색하여 실행합니다
+
+            ### 포함된 파일
+            - `CoTalk.msix` - 앱 패키지
+            - `Co-Talk 설치.bat` - 설치 스크립트 (이것만 실행하면 됩니다!)
+            - `Co-Talk 제거.bat` - 제거 스크립트
+            - `README.txt` - 설치 가이드
 
             ### 요구 사항
             - Windows 10 버전 1809 이상
-          files: ./release/CoTalk.msix
+            - x64 아키텍처
+          files: ./release/CoTalk-Windows-v${{ steps.version.outputs.version }}.zip
           draft: true
           generate_release_notes: true

--- a/installer/Co-Talk 설치.bat
+++ b/installer/Co-Talk 설치.bat
@@ -1,0 +1,13 @@
+@echo off
+chcp 65001 >nul
+title Co-Talk 설치
+echo.
+echo ==========================================
+echo        Co-Talk 설치를 시작합니다
+echo ==========================================
+echo.
+echo 관리자 권한이 필요합니다.
+echo 권한 요청 창이 나타나면 '예'를 클릭해주세요.
+echo.
+
+PowerShell -NoProfile -ExecutionPolicy Bypass -File "%~dp0install.ps1"

--- a/installer/Co-Talk 제거.bat
+++ b/installer/Co-Talk 제거.bat
@@ -1,0 +1,13 @@
+@echo off
+chcp 65001 >nul
+title Co-Talk 제거
+echo.
+echo ==========================================
+echo        Co-Talk 제거를 시작합니다
+echo ==========================================
+echo.
+echo 관리자 권한이 필요합니다.
+echo 권한 요청 창이 나타나면 '예'를 클릭해주세요.
+echo.
+
+PowerShell -NoProfile -ExecutionPolicy Bypass -File "%~dp0install.ps1" -Uninstall

--- a/installer/install.ps1
+++ b/installer/install.ps1
@@ -1,0 +1,148 @@
+# Co-Talk 설치 스크립트
+# 이 스크립트는 관리자 권한으로 실행해야 합니다.
+
+param(
+    [switch]$Uninstall
+)
+
+$ErrorActionPreference = "Stop"
+$AppName = "Co-Talk"
+$Publisher = "CN=Co-Talk"
+
+# 색상 출력 함수
+function Write-ColorOutput($ForegroundColor, $Message) {
+    $fc = $host.UI.RawUI.ForegroundColor
+    $host.UI.RawUI.ForegroundColor = $ForegroundColor
+    Write-Output $Message
+    $host.UI.RawUI.ForegroundColor = $fc
+}
+
+function Write-Info($Message) { Write-ColorOutput "Cyan" "[INFO] $Message" }
+function Write-Success($Message) { Write-ColorOutput "Green" "[SUCCESS] $Message" }
+function Write-Warning($Message) { Write-ColorOutput "Yellow" "[WARNING] $Message" }
+function Write-Error($Message) { Write-ColorOutput "Red" "[ERROR] $Message" }
+
+# 관리자 권한 확인
+function Test-Administrator {
+    $currentUser = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($currentUser)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+# 관리자 권한으로 재실행
+if (-not (Test-Administrator)) {
+    Write-Warning "관리자 권한이 필요합니다. 관리자 권한으로 재실행합니다..."
+    $scriptPath = $MyInvocation.MyCommand.Path
+    $arguments = "-NoProfile -ExecutionPolicy Bypass -File `"$scriptPath`""
+    if ($Uninstall) { $arguments += " -Uninstall" }
+    Start-Process PowerShell -Verb RunAs -ArgumentList $arguments
+    exit
+}
+
+Write-Output ""
+Write-Output "=========================================="
+Write-Output "       $AppName 설치 프로그램"
+Write-Output "=========================================="
+Write-Output ""
+
+# 스크립트 경로 기준으로 MSIX 파일 찾기
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$msixFiles = Get-ChildItem -Path $scriptDir -Filter "*.msix" -ErrorAction SilentlyContinue
+
+if ($msixFiles.Count -eq 0) {
+    Write-Error "MSIX 파일을 찾을 수 없습니다."
+    Write-Error "이 스크립트와 같은 폴더에 MSIX 파일을 넣어주세요."
+    Read-Host "아무 키나 눌러 종료하세요"
+    exit 1
+}
+
+$msixPath = $msixFiles[0].FullName
+Write-Info "MSIX 파일: $($msixFiles[0].Name)"
+
+# 제거 모드
+if ($Uninstall) {
+    Write-Info "$AppName 제거 중..."
+    
+    # 앱 패키지 제거
+    $packages = Get-AppxPackage | Where-Object { $_.Name -like "*cotalk*" -or $_.Name -like "*co-talk*" }
+    foreach ($package in $packages) {
+        Write-Info "앱 제거 중: $($package.Name)"
+        Remove-AppxPackage -Package $package.PackageFullName
+    }
+    
+    # 인증서 제거
+    $certs = Get-ChildItem -Path "Cert:\LocalMachine\Root" | Where-Object { $_.Subject -eq $Publisher }
+    foreach ($cert in $certs) {
+        Write-Info "인증서 제거 중: $($cert.Thumbprint)"
+        Remove-Item -Path "Cert:\LocalMachine\Root\$($cert.Thumbprint)" -Force
+    }
+    
+    Write-Success "$AppName 제거가 완료되었습니다!"
+    Read-Host "아무 키나 눌러 종료하세요"
+    exit 0
+}
+
+# 설치 모드
+try {
+    # 1. MSIX에서 인증서 추출
+    Write-Info "인증서 추출 중..."
+    $signature = Get-AuthenticodeSignature -FilePath $msixPath
+    
+    if ($null -eq $signature.SignerCertificate) {
+        Write-Error "MSIX 파일에서 서명을 찾을 수 없습니다."
+        Read-Host "아무 키나 눌러 종료하세요"
+        exit 1
+    }
+    
+    $cert = $signature.SignerCertificate
+    Write-Info "인증서 발급자: $($cert.Subject)"
+    Write-Info "인증서 지문: $($cert.Thumbprint)"
+    
+    # 2. 인증서가 이미 설치되어 있는지 확인
+    $existingCert = Get-ChildItem -Path "Cert:\LocalMachine\Root" | Where-Object { $_.Thumbprint -eq $cert.Thumbprint }
+    
+    if ($existingCert) {
+        Write-Info "인증서가 이미 설치되어 있습니다."
+    } else {
+        # 3. 인증서를 신뢰할 수 있는 루트 인증 기관에 설치
+        Write-Info "인증서를 신뢰할 수 있는 루트 인증 기관에 설치 중..."
+        
+        $certPath = Join-Path $env:TEMP "cotalk_cert.cer"
+        Export-Certificate -Cert $cert -FilePath $certPath | Out-Null
+        Import-Certificate -FilePath $certPath -CertStoreLocation "Cert:\LocalMachine\Root" | Out-Null
+        Remove-Item $certPath -Force -ErrorAction SilentlyContinue
+        
+        Write-Success "인증서 설치 완료!"
+    }
+    
+    # 4. 기존 앱이 있으면 제거
+    Write-Info "기존 설치 확인 중..."
+    $existingPackages = Get-AppxPackage | Where-Object { $_.Name -like "*cotalk*" -or $_.Name -like "*co-talk*" }
+    
+    if ($existingPackages) {
+        Write-Info "기존 버전 제거 중..."
+        foreach ($package in $existingPackages) {
+            Remove-AppxPackage -Package $package.PackageFullName -ErrorAction SilentlyContinue
+        }
+    }
+    
+    # 5. MSIX 앱 설치
+    Write-Info "$AppName 설치 중..."
+    Add-AppxPackage -Path $msixPath
+    
+    Write-Output ""
+    Write-Success "=========================================="
+    Write-Success "    $AppName 설치가 완료되었습니다!"
+    Write-Success "=========================================="
+    Write-Output ""
+    Write-Info "시작 메뉴에서 '$AppName'을 검색하여 실행하세요."
+    Write-Output ""
+    
+} catch {
+    Write-Output ""
+    Write-Error "설치 중 오류가 발생했습니다:"
+    Write-Error $_.Exception.Message
+    Write-Output ""
+}
+
+Read-Host "아무 키나 눌러 종료하세요"

--- a/scripts/build_release.bat
+++ b/scripts/build_release.bat
@@ -1,0 +1,6 @@
+@echo off
+chcp 65001 >nul
+title Co-Talk 릴리즈 빌드
+
+cd /d "%~dp0.."
+PowerShell -NoProfile -ExecutionPolicy Bypass -File "%~dp0build_release.ps1"

--- a/scripts/build_release.ps1
+++ b/scripts/build_release.ps1
@@ -1,0 +1,155 @@
+# Co-Talk Windows 릴리즈 빌드 스크립트
+# 이 스크립트는 프로젝트 루트에서 실행해야 합니다.
+
+$ErrorActionPreference = "Stop"
+$AppName = "Co-Talk"
+$ProjectRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+
+Set-Location $ProjectRoot
+
+Write-Host ""
+Write-Host "==========================================" -ForegroundColor Cyan
+Write-Host "       $AppName Windows 릴리즈 빌드" -ForegroundColor Cyan
+Write-Host "==========================================" -ForegroundColor Cyan
+Write-Host ""
+
+# 1. Flutter 빌드
+Write-Host "[1/4] Flutter Windows 빌드 중..." -ForegroundColor Yellow
+flutter build windows --release --dart-define=ENVIRONMENT=prod
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "Flutter 빌드 실패!" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "[1/4] Flutter 빌드 완료!" -ForegroundColor Green
+
+# 2. MSIX 패키지 생성
+Write-Host ""
+Write-Host "[2/4] MSIX 패키지 생성 중..." -ForegroundColor Yellow
+flutter pub run msix:create
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "MSIX 생성 실패!" -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "[2/4] MSIX 패키지 생성 완료!" -ForegroundColor Green
+
+# 3. 배포 폴더 생성
+Write-Host ""
+Write-Host "[3/4] 배포 패키지 생성 중..." -ForegroundColor Yellow
+
+$releaseDir = Join-Path $ProjectRoot "release"
+$distDir = Join-Path $releaseDir "CoTalk-Windows"
+
+# 기존 폴더 삭제
+if (Test-Path $distDir) {
+    Remove-Item $distDir -Recurse -Force
+}
+
+New-Item -ItemType Directory -Path $distDir -Force | Out-Null
+
+# MSIX 파일 찾기 및 복사
+$msixFiles = Get-ChildItem -Path (Join-Path $ProjectRoot "build\windows\x64\runner\Release") -Filter "*.msix" -Recurse -ErrorAction SilentlyContinue
+
+if ($msixFiles.Count -eq 0) {
+    # 다른 경로에서도 찾기
+    $msixFiles = Get-ChildItem -Path $ProjectRoot -Filter "*.msix" -Recurse -ErrorAction SilentlyContinue | Where-Object { $_.DirectoryName -notlike "*release*" }
+}
+
+if ($msixFiles.Count -eq 0) {
+    Write-Host "MSIX 파일을 찾을 수 없습니다!" -ForegroundColor Red
+    exit 1
+}
+
+$msixPath = $msixFiles[0].FullName
+Copy-Item $msixPath -Destination $distDir
+
+# 설치 스크립트 복사
+$installerDir = Join-Path $ProjectRoot "installer"
+Copy-Item (Join-Path $installerDir "install.ps1") -Destination $distDir
+Copy-Item (Join-Path $installerDir "Co-Talk 설치.bat") -Destination $distDir
+Copy-Item (Join-Path $installerDir "Co-Talk 제거.bat") -Destination $distDir
+
+Write-Host "[3/4] 배포 패키지 생성 완료!" -ForegroundColor Green
+
+# 4. 버전 정보 추출 및 README 생성
+Write-Host ""
+Write-Host "[4/4] README 생성 중..." -ForegroundColor Yellow
+
+$pubspec = Get-Content (Join-Path $ProjectRoot "pubspec.yaml") -Raw
+if ($pubspec -match 'version:\s*(\d+\.\d+\.\d+)') {
+    $version = $Matches[1]
+} else {
+    $version = "1.0.0"
+}
+
+$readme = @"
+# $AppName v$version - Windows 설치 가이드
+
+## 설치 방법
+
+1. **'Co-Talk 설치.bat'** 파일을 **더블클릭**하세요.
+2. 관리자 권한 요청 창이 나타나면 **'예'**를 클릭하세요.
+3. 설치가 완료되면 시작 메뉴에서 **'Co-Talk'**을 검색하여 실행하세요.
+
+## 제거 방법
+
+1. **'Co-Talk 제거.bat'** 파일을 **더블클릭**하세요.
+2. 관리자 권한 요청 창이 나타나면 **'예'**를 클릭하세요.
+
+## 포함된 파일
+
+- **CoTalk.msix** - 앱 패키지
+- **Co-Talk 설치.bat** - 설치 스크립트
+- **Co-Talk 제거.bat** - 제거 스크립트
+- **install.ps1** - PowerShell 설치 스크립트
+- **README.txt** - 이 파일
+
+## 시스템 요구사항
+
+- Windows 10 버전 1809 (빌드 17763) 이상
+- x64 아키텍처
+
+## 문제 해결
+
+설치 중 문제가 발생하면:
+1. Windows를 최신 버전으로 업데이트하세요.
+2. 바이러스 백신 프로그램을 일시적으로 비활성화해보세요.
+3. 다른 사용자 계정으로 설치를 시도해보세요.
+
+---
+빌드 날짜: $(Get-Date -Format "yyyy-MM-dd HH:mm:ss")
+"@
+
+$readme | Out-File -FilePath (Join-Path $distDir "README.txt") -Encoding UTF8
+
+Write-Host "[4/4] README 생성 완료!" -ForegroundColor Green
+
+# 완료 메시지
+Write-Host ""
+Write-Host "==========================================" -ForegroundColor Green
+Write-Host "       빌드 및 패키징 완료!" -ForegroundColor Green
+Write-Host "==========================================" -ForegroundColor Green
+Write-Host ""
+Write-Host "배포 폴더: $distDir" -ForegroundColor Cyan
+Write-Host ""
+Write-Host "포함된 파일:" -ForegroundColor Yellow
+Get-ChildItem $distDir | ForEach-Object { Write-Host "  - $($_.Name)" }
+Write-Host ""
+
+# ZIP 파일 생성 여부 확인
+$createZip = Read-Host "ZIP 파일로 압축하시겠습니까? (Y/N)"
+if ($createZip -eq "Y" -or $createZip -eq "y") {
+    $zipPath = Join-Path $releaseDir "CoTalk-Windows-v$version.zip"
+    if (Test-Path $zipPath) {
+        Remove-Item $zipPath -Force
+    }
+    Compress-Archive -Path "$distDir\*" -DestinationPath $zipPath
+    Write-Host ""
+    Write-Host "ZIP 파일 생성 완료: $zipPath" -ForegroundColor Green
+}
+
+Write-Host ""
+Read-Host "아무 키나 눌러 종료하세요"


### PR DESCRIPTION
## 📋 개요

Windows MSIX 패키지 설치 시 자체 서명 인증서 오류(0x800B010A)를 해결하기 위한 설치 스크립트를 추가합니다.

사용자가 \Co-Talk 설치.bat\를 더블클릭하면 인증서 설치 + 앱 설치가 한번에 완료됩니다.

## 🎯 변경사항

### 1. 설치 스크립트 추가 (\installer/\)
| 파일 | 설명 |
|------|------|
| \install.ps1\ | PowerShell 설치 스크립트 (인증서 추출 및 설치) |
| \Co-Talk 설치.bat\ | 더블클릭으로 실행 가능한 배치 파일 |
| \Co-Talk 제거.bat\ | 앱 및 인증서 제거 스크립트 |

### 2. 로컬 빌드 스크립트 추가 (\scripts/\)
| 파일 | 설명 |
|------|------|
| \uild_release.ps1\ | 릴리즈 빌드 자동화 스크립트 |
| \uild_release.bat\ | 더블클릭으로 빌드 실행 |

### 3. GitHub Actions 업데이트
- MSIX + 설치 스크립트를 ZIP으로 패키징하여 배포
- Release 노트에 새로운 설치 방법 안내 추가

## 📊 통계
- 변경 파일: 6개
- 추가: +390줄, 삭제: -6줄
- 커밋: 3개

## 🔗 관련 이슈
Closes #43

## ✅ 체크리스트
- [x] 설치 스크립트 작성
- [x] 로컬 빌드 스크립트 작성
- [x] GitHub Actions 워크플로우 업데이트

## 📝 테스트 방법
1. \scripts/build_release.bat\ 실행하여 로컬 빌드
2. \elease/CoTalk-Windows/\ 폴더에서 \Co-Talk 설치.bat\ 실행
3. 관리자 권한 요청 시 '예' 클릭
4. 시작 메뉴에서 'Co-Talk' 검색하여 실행 확인