### PR TITLE
feat(media): 이미지 Hero 전환 + 프로필 이미지 캐싱

### DIFF
--- a/lib/presentation/pages/chat/widgets/message_bubble.dart
+++ b/lib/presentation/pages/chat/widgets/message_bubble.dart
@@ -1437,7 +1437,7 @@ class _DismissibleImageViewerState extends State<_DismissibleImageViewer>
   // scale > 1.0 일 때만 panEnabled = true 로 설정해 드래그-투-디스미스와 충돌 방지.
   final TransformationController _transformationController =
       TransformationController();
-  double _currentScale = 1.0;
+  bool _panEnabled = false;
 
   static const double _dismissThreshold = 100;
   static const double _velocityThreshold = 500;
@@ -1467,10 +1467,14 @@ class _DismissibleImageViewerState extends State<_DismissibleImageViewer>
   }
 
   void _onInteractionUpdate(ScaleUpdateDetails details) {
-    final scale = _transformationController.value.getMaxScaleOnAxis();
-    if (scale != _currentScale) {
+    // panEnabled 분기에 필요한 건 (scale > 1.0) boolean 전환 시점뿐이므로,
+    // scale 값 자체가 아니라 boolean 이 직전 값과 달라질 때만 setState 하여
+    // 줌 중 build/CachedNetworkImage 의 불필요한 리빌드를 줄인다.
+    final panEnabled =
+        _transformationController.value.getMaxScaleOnAxis() > 1.0;
+    if (panEnabled != _panEnabled) {
       setState(() {
-        _currentScale = scale;
+        _panEnabled = panEnabled;
       });
     }
   }
@@ -1534,7 +1538,7 @@ class _DismissibleImageViewerState extends State<_DismissibleImageViewer>
                 child: InteractiveViewer(
                   // scale == 1.0 일 때 pan 을 비활성화하여 드래그-투-디스미스 제스처가 동작하도록 함.
                   // zoom 상태에서는 pan 활성화하여 정상 이동 가능.
-                  panEnabled: _currentScale > 1.0,
+                  panEnabled: _panEnabled,
                   transformationController: _transformationController,
                   onInteractionUpdate: _onInteractionUpdate,
                   minScale: 0.5,

--- a/lib/presentation/pages/chat/widgets/message_bubble.dart
+++ b/lib/presentation/pages/chat/widgets/message_bubble.dart
@@ -326,7 +326,7 @@ class MessageBubble extends StatelessWidget {
   }
 
   /// Shows image options bottom sheet (fullscreen, save to gallery, delete)
-  void _showImageOptions(BuildContext context, String imageUrl) {
+  void _showImageOptions(BuildContext context, String imageUrl, {String? heroTag}) {
     final canDelete = isMe && !message.isDeleted && !_isEditTimeExpired;
 
     showModalBottomSheet(
@@ -356,7 +356,7 @@ class MessageBubble extends StatelessWidget {
                 title: const Text('전체 화면 보기'),
                 onTap: () {
                   Navigator.pop(sheetContext);
-                  _showFullScreenImage(context, imageUrl);
+                  _showFullScreenImage(context, imageUrl, heroTag: heroTag);
                 },
               ),
               if (!kIsWeb)
@@ -386,7 +386,7 @@ class MessageBubble extends StatelessWidget {
   }
 
   /// Shows fullscreen image viewer with drag-to-dismiss (KakaoTalk style)
-  void _showFullScreenImage(BuildContext context, String imageUrl) {
+  void _showFullScreenImage(BuildContext context, String imageUrl, {String? heroTag}) {
     Navigator.of(context).push(
       PageRouteBuilder(
         opaque: false,
@@ -394,6 +394,7 @@ class MessageBubble extends StatelessWidget {
         pageBuilder: (context, animation, secondaryAnimation) {
           return _DismissibleImageViewer(
             imageUrl: imageUrl,
+            heroTag: heroTag,
             onSaveToGallery: kIsWeb ? null : () => _saveImageToGallery(context, imageUrl),
           );
         },
@@ -876,15 +877,17 @@ class MessageBubble extends StatelessWidget {
     // Image message
     if (message.type == MessageType.image && message.fileUrl != null) {
       final imageUrl = message.fileUrl!;
+      final heroTag = 'chat_image_${message.id}';
       final chatSettings = context.read<ChatSettingsCubit>().state.settings;
       final autoDownload = chatSettings.autoDownloadImagesOnWifi; // Use wifi setting as the general toggle
 
       bubbleWidget = _AutoDownloadImageWidget(
         imageUrl: imageUrl,
+        heroTag: heroTag,
         isMe: isMe,
         autoDownloadEnabled: autoDownload,
-        onTapFullScreen: () => _showFullScreenImage(context, imageUrl),
-        onLongPress: _showImageOptions,
+        onTapFullScreen: () => _showFullScreenImage(context, imageUrl, heroTag: heroTag),
+        onLongPress: (ctx, url) => _showImageOptions(ctx, url, heroTag: heroTag),
       );
     }
     // Video message
@@ -1230,6 +1233,7 @@ class MessageBubble extends StatelessWidget {
 /// 자동 다운로드 설정에 따라 이미지를 로드하는 위젯
 class _AutoDownloadImageWidget extends StatefulWidget {
   final String imageUrl;
+  final String? heroTag;
   final bool isMe;
   final bool autoDownloadEnabled;
   final VoidCallback onTapFullScreen;
@@ -1237,6 +1241,7 @@ class _AutoDownloadImageWidget extends StatefulWidget {
 
   const _AutoDownloadImageWidget({
     required this.imageUrl,
+    this.heroTag,
     required this.isMe,
     required this.autoDownloadEnabled,
     required this.onTapFullScreen,
@@ -1299,6 +1304,35 @@ class _AutoDownloadImageWidgetState extends State<_AutoDownloadImageWidget> {
       );
     }
 
+    final cachedImage = CachedNetworkImage(
+      imageUrl: widget.imageUrl,
+      fit: BoxFit.cover,
+      placeholder: (context, url) => Container(
+        width: 200,
+        height: 150,
+        color: context.dividerColor,
+        child: const Center(
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      ),
+      errorWidget: (context, url, error) => Container(
+        width: 200,
+        height: 150,
+        color: context.dividerColor,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.broken_image, color: context.textSecondaryColor, size: 40),
+            const SizedBox(height: 8),
+            Text(
+              '이미지를 불러올 수 없습니다',
+              style: TextStyle(color: context.textSecondaryColor, fontSize: 12),
+            ),
+          ],
+        ),
+      ),
+    );
+
     return GestureDetector(
       onTap: widget.onTapFullScreen,
       onLongPress: () => widget.onLongPress(context, widget.imageUrl),
@@ -1314,34 +1348,9 @@ class _AutoDownloadImageWidgetState extends State<_AutoDownloadImageWidget> {
             maxWidth: MediaQuery.of(context).size.width * 0.65,
             maxHeight: 250,
           ),
-          child: CachedNetworkImage(
-            imageUrl: widget.imageUrl,
-            fit: BoxFit.cover,
-            placeholder: (context, url) => Container(
-              width: 200,
-              height: 150,
-              color: context.dividerColor,
-              child: const Center(
-                child: CircularProgressIndicator(strokeWidth: 2),
-              ),
-            ),
-            errorWidget: (context, url, error) => Container(
-              width: 200,
-              height: 150,
-              color: context.dividerColor,
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Icon(Icons.broken_image, color: context.textSecondaryColor, size: 40),
-                  const SizedBox(height: 8),
-                  Text(
-                    '이미지를 불러올 수 없습니다',
-                    style: TextStyle(color: context.textSecondaryColor, fontSize: 12),
-                  ),
-                ],
-              ),
-            ),
-          ),
+          child: widget.heroTag != null
+              ? Hero(tag: widget.heroTag!, child: cachedImage)
+              : cachedImage,
         ),
       ),
     );
@@ -1351,10 +1360,12 @@ class _AutoDownloadImageWidgetState extends State<_AutoDownloadImageWidget> {
 /// 드래그로 닫을 수 있는 전체화면 이미지 뷰어 (카카오톡 스타일)
 class _DismissibleImageViewer extends StatefulWidget {
   final String imageUrl;
+  final String? heroTag;
   final VoidCallback? onSaveToGallery;
 
   const _DismissibleImageViewer({
     required this.imageUrl,
+    this.heroTag,
     this.onSaveToGallery,
   });
 
@@ -1455,17 +1466,25 @@ class _DismissibleImageViewerState extends State<_DismissibleImageViewer>
                   panEnabled: true,
                   minScale: 0.5,
                   maxScale: 4,
-                  child: CachedNetworkImage(
-                    imageUrl: widget.imageUrl,
-                    fit: BoxFit.contain,
-                    placeholder: (context, url) => const Center(
-                      child: CircularProgressIndicator(
-                        color: Colors.white,
-                      ),
-                    ),
-                    errorWidget: (context, url, error) => const Center(
-                      child: Icon(Icons.broken_image, color: Colors.white54, size: 80),
-                    ),
+                  child: Builder(
+                    builder: (context) {
+                      final image = CachedNetworkImage(
+                        imageUrl: widget.imageUrl,
+                        fit: BoxFit.contain,
+                        placeholder: (context, url) => const Center(
+                          child: CircularProgressIndicator(
+                            color: Colors.white,
+                          ),
+                        ),
+                        errorWidget: (context, url, error) => const Center(
+                          child: Icon(Icons.broken_image, color: Colors.white54, size: 80),
+                        ),
+                      );
+                      if (widget.heroTag != null) {
+                        return Hero(tag: widget.heroTag!, child: image);
+                      }
+                      return image;
+                    },
                   ),
                 ),
               ),

--- a/lib/presentation/pages/chat/widgets/message_bubble.dart
+++ b/lib/presentation/pages/chat/widgets/message_bubble.dart
@@ -877,9 +877,15 @@ class MessageBubble extends StatelessWidget {
     // Image message
     if (message.type == MessageType.image && message.fileUrl != null) {
       final imageUrl = message.fileUrl!;
+      // Hero 태그는 출처(chat 버블 이미지)를 prefix 로 명시해 추후 충돌 추적을 쉽게 한다.
       // TODO(hero-tag): 답장 미리보기 썸네일이나 갤러리 Hero를 추가할 경우
       // 동일 route 안에서 'chat_image_<id>' 태그가 충돌할 수 있음 →
       // 용도별로 네임스페이스를 분리해야 함 (예: 'chat_thumb_<id>', 'gallery_<id>' 등).
+      // 디버그 빌드에서 잘못된 id(중복 유발 가능)를 일찍 잡기 위한 가드.
+      assert(
+        message.id != 0,
+        'Hero 태그 생성에 유효한 message.id 가 필요합니다 (중복 태그 방지).',
+      );
       final heroTag = 'chat_image_${message.id}';
       final chatSettings = context.read<ChatSettingsCubit>().state.settings;
       final autoDownload = chatSettings.autoDownloadImagesOnWifi; // Use wifi setting as the general toggle

--- a/lib/presentation/pages/chat/widgets/message_bubble.dart
+++ b/lib/presentation/pages/chat/widgets/message_bubble.dart
@@ -877,6 +877,9 @@ class MessageBubble extends StatelessWidget {
     // Image message
     if (message.type == MessageType.image && message.fileUrl != null) {
       final imageUrl = message.fileUrl!;
+      // TODO(hero-tag): 답장 미리보기 썸네일이나 갤러리 Hero를 추가할 경우
+      // 동일 route 안에서 'chat_image_<id>' 태그가 충돌할 수 있음 →
+      // 용도별로 네임스페이스를 분리해야 함 (예: 'chat_thumb_<id>', 'gallery_<id>' 등).
       final heroTag = 'chat_image_${message.id}';
       final chatSettings = context.read<ChatSettingsCubit>().state.settings;
       final autoDownload = chatSettings.autoDownloadImagesOnWifi; // Use wifi setting as the general toggle
@@ -1333,26 +1336,62 @@ class _AutoDownloadImageWidgetState extends State<_AutoDownloadImageWidget> {
       ),
     );
 
+    final borderRadius = BorderRadius.only(
+      topLeft: const Radius.circular(18),
+      topRight: const Radius.circular(18),
+      bottomLeft: Radius.circular(widget.isMe ? 18 : 4),
+      bottomRight: Radius.circular(widget.isMe ? 4 : 18),
+    );
+
+    // ClipRRect를 Hero 자식으로 넣어 Hero 비행 중에도 동일한 클리핑이 유지되도록 함.
+    // (ClipRRect를 Hero 바깥에 두면 비행 오버레이에서는 클리핑이 적용되지 않아 시각적 글리치 발생)
+    Widget imageChild = ClipRRect(
+      borderRadius: borderRadius,
+      child: Container(
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.of(context).size.width * 0.65,
+          maxHeight: 250,
+        ),
+        child: cachedImage,
+      ),
+    );
+
     return GestureDetector(
       onTap: widget.onTapFullScreen,
       onLongPress: () => widget.onLongPress(context, widget.imageUrl),
-      child: ClipRRect(
-        borderRadius: BorderRadius.only(
-          topLeft: const Radius.circular(18),
-          topRight: const Radius.circular(18),
-          bottomLeft: Radius.circular(widget.isMe ? 18 : 4),
-          bottomRight: Radius.circular(widget.isMe ? 4 : 18),
-        ),
-        child: Container(
-          constraints: BoxConstraints(
-            maxWidth: MediaQuery.of(context).size.width * 0.65,
-            maxHeight: 250,
-          ),
-          child: widget.heroTag != null
-              ? Hero(tag: widget.heroTag!, child: cachedImage)
-              : cachedImage,
-        ),
-      ),
+      child: widget.heroTag != null
+          ? Hero(
+              tag: widget.heroTag!,
+              // 비행 중에도 버블 측 둥근 모서리가 자연스럽게 유지됨
+              flightShuttleBuilder: (_, animation, direction, __, ___) {
+                return AnimatedBuilder(
+                  animation: animation,
+                  builder: (context, child) {
+                    // 출발(버블) → 도착(전체화면) 방향에 따라 radius를 보간
+                    final t = direction == HeroFlightDirection.push
+                        ? animation.value
+                        : 1 - animation.value;
+                    final radius = BorderRadius.lerp(
+                      borderRadius,
+                      BorderRadius.zero,
+                      t,
+                    )!;
+                    return ClipRRect(
+                      borderRadius: radius,
+                      child: Container(
+                        constraints: BoxConstraints(
+                          maxWidth: MediaQuery.of(context).size.width * 0.65,
+                          maxHeight: 250,
+                        ),
+                        child: cachedImage,
+                      ),
+                    );
+                  },
+                );
+              },
+              child: imageChild,
+            )
+          : imageChild,
     );
   }
 }
@@ -1380,6 +1419,12 @@ class _DismissibleImageViewerState extends State<_DismissibleImageViewer>
   late AnimationController _animationController;
   late Animation<double> _animation;
 
+  // InteractiveViewer 줌 상태 추적용 컨트롤러.
+  // scale > 1.0 일 때만 panEnabled = true 로 설정해 드래그-투-디스미스와 충돌 방지.
+  final TransformationController _transformationController =
+      TransformationController();
+  double _currentScale = 1.0;
+
   static const double _dismissThreshold = 100;
   static const double _velocityThreshold = 500;
 
@@ -1403,7 +1448,17 @@ class _DismissibleImageViewerState extends State<_DismissibleImageViewer>
   @override
   void dispose() {
     _animationController.dispose();
+    _transformationController.dispose();
     super.dispose();
+  }
+
+  void _onInteractionUpdate(ScaleUpdateDetails details) {
+    final scale = _transformationController.value.getMaxScaleOnAxis();
+    if (scale != _currentScale) {
+      setState(() {
+        _currentScale = scale;
+      });
+    }
   }
 
   void _onVerticalDragUpdate(DragUpdateDetails details) {
@@ -1463,7 +1518,11 @@ class _DismissibleImageViewerState extends State<_DismissibleImageViewer>
               child: Transform.scale(
                 scale: scale,
                 child: InteractiveViewer(
-                  panEnabled: true,
+                  // scale == 1.0 일 때 pan 을 비활성화하여 드래그-투-디스미스 제스처가 동작하도록 함.
+                  // zoom 상태에서는 pan 활성화하여 정상 이동 가능.
+                  panEnabled: _currentScale > 1.0,
+                  transformationController: _transformationController,
+                  onInteractionUpdate: _onInteractionUpdate,
                   minScale: 0.5,
                   maxScale: 4,
                   child: Builder(

--- a/lib/presentation/pages/chat/widgets/message_bubble.dart
+++ b/lib/presentation/pages/chat/widgets/message_bubble.dart
@@ -1313,9 +1313,17 @@ class _AutoDownloadImageWidgetState extends State<_AutoDownloadImageWidget> {
       );
     }
 
+    // 버블 썸네일은 화면상 maxWidth(= 화면폭 * 0.65) 로만 표시되므로,
+    // 디바이스 픽셀비를 곱한 적정 폭으로 memCacheWidth 를 지정해 서버 원본 해상도가
+    // 그대로 디코딩되어 메모리에 상주하는 것을 방지한다. (전체화면 뷰어는 풀해상도 유지)
+    final mq = MediaQuery.of(context);
+    final thumbCacheWidth =
+        (mq.size.width * 0.65 * mq.devicePixelRatio).round();
+
     final cachedImage = CachedNetworkImage(
       imageUrl: widget.imageUrl,
       fit: BoxFit.cover,
+      memCacheWidth: thumbCacheWidth,
       placeholder: (context, url) => Container(
         width: 200,
         height: 150,

--- a/lib/presentation/pages/profile/profile_history_page.dart
+++ b/lib/presentation/pages/profile/profile_history_page.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -422,7 +423,7 @@ class _ImageViewState extends State<_ImageView> {
     if (_isZoomed) {
       _transformationController.value = Matrix4.identity();
     } else {
-      _transformationController.value = Matrix4.identity()..scale(2.0);
+      _transformationController.value = Matrix4.identity()..scaleByDouble(2.0, 2.0, 2.0, 1.0);
     }
   }
 
@@ -450,22 +451,13 @@ class _ImageViewState extends State<_ImageView> {
         // 확대 중일 때만 pan 활성화 (기본 상태에서는 PageView 스와이프 허용)
         panEnabled: _isZoomed,
         child: Center(
-          child: Image.network(
-            widget.url!,
+          child: CachedNetworkImage(
+            imageUrl: widget.url!,
             fit: BoxFit.contain,
-            loadingBuilder: (context, child, loadingProgress) {
-              if (loadingProgress == null) return child;
-              return Center(
-                child: CircularProgressIndicator(
-                  value: loadingProgress.expectedTotalBytes != null
-                      ? loadingProgress.cumulativeBytesLoaded /
-                          loadingProgress.expectedTotalBytes!
-                      : null,
-                  color: Colors.white,
-                ),
-              );
-            },
-            errorBuilder: (_, __, ___) => const Center(
+            placeholder: (_, __) => const Center(
+              child: CircularProgressIndicator(color: Colors.white),
+            ),
+            errorWidget: (_, __, ___) => const Center(
               child: Icon(
                 Icons.broken_image,
                 color: Colors.white54,

--- a/lib/presentation/pages/profile/profile_view_page.dart
+++ b/lib/presentation/pages/profile/profile_view_page.dart
@@ -699,7 +699,7 @@ class _BackgroundImage extends StatelessWidget {
   }
 }
 
-class _ProfileAvatar extends StatelessWidget {
+class _ProfileAvatar extends StatefulWidget {
   final String? url;
   final String nickname;
 
@@ -709,7 +709,28 @@ class _ProfileAvatar extends StatelessWidget {
   });
 
   @override
+  State<_ProfileAvatar> createState() => _ProfileAvatarState();
+}
+
+class _ProfileAvatarState extends State<_ProfileAvatar> {
+  // 이미지 로드 실패를 추적해 이니셜 텍스트 fallback 으로 되돌린다.
+  // (ImageProvider 경로에는 errorWidget 이 없어 실패 시 빈 원이 남는 문제 방지)
+  bool _imageLoadFailed = false;
+
+  @override
+  void didUpdateWidget(covariant _ProfileAvatar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // url 이 바뀌면 실패 플래그를 초기화해 새 이미지 로드를 다시 시도한다.
+    if (oldWidget.url != widget.url) {
+      _imageLoadFailed = false;
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final url = widget.url;
+    final showImage = url != null && !_imageLoadFailed;
+
     return Container(
       decoration: BoxDecoration(
         shape: BoxShape.circle,
@@ -725,17 +746,27 @@ class _ProfileAvatar extends StatelessWidget {
       child: CircleAvatar(
         radius: 50,
         backgroundColor: AppColors.primaryLight,
-        backgroundImage: url != null ? CachedNetworkImageProvider(url!) : null,
-        child: url == null
-            ? Text(
-                nickname.isNotEmpty ? nickname[0].toUpperCase() : '?',
+        backgroundImage:
+            showImage ? CachedNetworkImageProvider(url) : null,
+        onBackgroundImageError: showImage
+            ? (_, __) {
+                if (mounted) {
+                  setState(() => _imageLoadFailed = true);
+                }
+              }
+            : null,
+        child: showImage
+            ? null
+            : Text(
+                widget.nickname.isNotEmpty
+                    ? widget.nickname[0].toUpperCase()
+                    : '?',
                 style: const TextStyle(
                   fontSize: 36,
                   fontWeight: FontWeight.bold,
                   color: Colors.white,
                 ),
-              )
-            : null,
+              ),
       ),
     );
   }

--- a/lib/presentation/pages/profile/profile_view_page.dart
+++ b/lib/presentation/pages/profile/profile_view_page.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -689,12 +690,11 @@ class _BackgroundImage extends StatelessWidget {
       );
     }
 
-    return Image.network(
-      url!,
+    return CachedNetworkImage(
+      imageUrl: url!,
       fit: BoxFit.cover,
-      errorBuilder: (_, __, ___) => Container(
-        color: AppColors.primaryDark,
-      ),
+      placeholder: (_, __) => Container(color: AppColors.primaryDark),
+      errorWidget: (_, __, ___) => Container(color: AppColors.primaryDark),
     );
   }
 }
@@ -725,7 +725,7 @@ class _ProfileAvatar extends StatelessWidget {
       child: CircleAvatar(
         radius: 50,
         backgroundColor: AppColors.primaryLight,
-        backgroundImage: url != null ? NetworkImage(url!) : null,
+        backgroundImage: url != null ? CachedNetworkImageProvider(url!) : null,
         child: url == null
             ? Text(
                 nickname.isNotEmpty ? nickname[0].toUpperCase() : '?',
@@ -1009,22 +1009,13 @@ class _DismissibleProfileImageViewerState
                   panEnabled: true,
                   minScale: 0.5,
                   maxScale: 4,
-                  child: Image.network(
-                    widget.imageUrl,
+                  child: CachedNetworkImage(
+                    imageUrl: widget.imageUrl,
                     fit: BoxFit.contain,
-                    loadingBuilder: (context, child, loadingProgress) {
-                      if (loadingProgress == null) return child;
-                      return Center(
-                        child: CircularProgressIndicator(
-                          color: Colors.white,
-                          value: loadingProgress.expectedTotalBytes != null
-                              ? loadingProgress.cumulativeBytesLoaded /
-                                  loadingProgress.expectedTotalBytes!
-                              : null,
-                        ),
-                      );
-                    },
-                    errorBuilder: (context, error, stackTrace) => const Center(
+                    placeholder: (_, __) => const Center(
+                      child: CircularProgressIndicator(color: Colors.white),
+                    ),
+                    errorWidget: (_, __, ___) => const Center(
                       child: Icon(Icons.broken_image, color: Colors.white54, size: 80),
                     ),
                   ),

--- a/lib/presentation/pages/profile/widgets/background_image_section.dart
+++ b/lib/presentation/pages/profile/widgets/background_image_section.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import '../../../../core/theme/app_colors.dart';
 
@@ -65,10 +66,20 @@ class BackgroundImageSection extends StatelessWidget {
     }
 
     if (backgroundUrl != null && backgroundUrl!.isNotEmpty) {
-      return Image.network(
-        backgroundUrl!,
+      return CachedNetworkImage(
+        imageUrl: backgroundUrl!,
         fit: BoxFit.cover,
-        errorBuilder: (_, __, ___) => Container(
+        placeholder: (_, __) => Container(
+          color: AppColors.primaryLight,
+          child: const Center(
+            child: SizedBox(
+              width: 24,
+              height: 24,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+          ),
+        ),
+        errorWidget: (_, __, ___) => Container(
           color: AppColors.primaryLight,
           child: const Center(child: Icon(Icons.broken_image)),
         ),

--- a/test/presentation/pages/chat/widgets/dismissible_image_viewer_test.dart
+++ b/test/presentation/pages/chat/widgets/dismissible_image_viewer_test.dart
@@ -40,6 +40,51 @@ void main() {
       expect(scale > 1.0, isFalse);
       controller.dispose();
     });
+
+    test(
+        'boolean 게이팅: scale 이 같은 boolean 구간 안에서 변해도 panEnabled 는 바뀌지 않는다 '
+        '(불필요한 setState 방지)', () {
+      // 프로덕션 _onInteractionUpdate 의 게이팅 로직을 그대로 재현.
+      final controller = TransformationController();
+      bool panEnabled = false;
+      int transitions = 0;
+
+      void onUpdate() {
+        final next = controller.value.getMaxScaleOnAxis() > 1.0;
+        if (next != panEnabled) {
+          panEnabled = next;
+          transitions++; // setState 가 호출되는 시점
+        }
+      }
+
+      // 1.0 → 1.0(미세 변화): false 유지, 전환 없음
+      controller.value = Matrix4.identity()..scale(1.0);
+      onUpdate();
+      expect(panEnabled, isFalse);
+      expect(transitions, 0);
+
+      // 1.0 → 1.5: false → true, 전환 1회
+      controller.value = Matrix4.identity()..scale(1.5);
+      onUpdate();
+      expect(panEnabled, isTrue);
+      expect(transitions, 1);
+
+      // 1.5 → 2.0 → 3.0: 모두 true 구간 → 추가 전환 없음
+      controller.value = Matrix4.identity()..scale(2.0);
+      onUpdate();
+      controller.value = Matrix4.identity()..scale(3.0);
+      onUpdate();
+      expect(panEnabled, isTrue);
+      expect(transitions, 1);
+
+      // 3.0 → 1.0: true → false, 전환 1회 추가
+      controller.value = Matrix4.identity();
+      onUpdate();
+      expect(panEnabled, isFalse);
+      expect(transitions, 2);
+
+      controller.dispose();
+    });
   });
 
   group('Hero + ClipRRect 구조 — bubble 측 borderRadius 보간', () {

--- a/test/presentation/pages/chat/widgets/dismissible_image_viewer_test.dart
+++ b/test/presentation/pages/chat/widgets/dismissible_image_viewer_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// _DismissibleImageViewer 는 private 이므로 message_bubble.dart 내부의
+// 공개 진입점(_showFullScreenImage)을 통해 동작을 검증한다.
+// 여기서는 panEnabled 게이팅과 Hero 클리핑 구조에 대한 단위 수준 검증을 담는다.
+
+// ── 헬퍼: TransformationController 를 직접 조작해 scale 을 확인하는 단위 테스트 ──
+
+void main() {
+  group('TransformationController scale gate (panEnabled logic)', () {
+    test('scale 1.0 → panEnabled false', () {
+      final controller = TransformationController();
+      // 초기 상태: 변환 없음 → scale == 1.0
+      final scale = controller.value.getMaxScaleOnAxis();
+      expect(scale, closeTo(1.0, 0.001));
+      // panEnabled 조건: scale > 1.0 → false
+      expect(scale > 1.0, isFalse);
+      controller.dispose();
+    });
+
+    test('zoom in → scale > 1.0 → panEnabled true', () {
+      final controller = TransformationController();
+      // 2× zoom 을 직접 주입
+      controller.value = Matrix4.identity()..scale(2.0);
+      final scale = controller.value.getMaxScaleOnAxis();
+      expect(scale, closeTo(2.0, 0.001));
+      // panEnabled 조건: scale > 1.0 → true
+      expect(scale > 1.0, isTrue);
+      controller.dispose();
+    });
+
+    test('zoom back to 1.0 → panEnabled false again', () {
+      final controller = TransformationController();
+      controller.value = Matrix4.identity()..scale(2.0);
+      // 다시 1× 로 되돌림
+      controller.value = Matrix4.identity();
+      final scale = controller.value.getMaxScaleOnAxis();
+      expect(scale, closeTo(1.0, 0.001));
+      expect(scale > 1.0, isFalse);
+      controller.dispose();
+    });
+  });
+
+  group('Hero + ClipRRect 구조 — bubble 측 borderRadius 보간', () {
+    test('lerp: t=0 → 버블 radius 유지', () {
+      final bubbleRadius = BorderRadius.only(
+        topLeft: const Radius.circular(18),
+        topRight: const Radius.circular(18),
+        bottomLeft: const Radius.circular(4),
+        bottomRight: const Radius.circular(18),
+      );
+      final result = BorderRadius.lerp(bubbleRadius, BorderRadius.zero, 0)!;
+      expect(result.topLeft.x, closeTo(18.0, 0.001));
+      expect(result.bottomLeft.x, closeTo(4.0, 0.001));
+    });
+
+    test('lerp: t=1 → BorderRadius.zero (전체화면 모서리 없음)', () {
+      final bubbleRadius = BorderRadius.only(
+        topLeft: const Radius.circular(18),
+        topRight: const Radius.circular(18),
+        bottomLeft: const Radius.circular(4),
+        bottomRight: const Radius.circular(18),
+      );
+      final result = BorderRadius.lerp(bubbleRadius, BorderRadius.zero, 1)!;
+      expect(result.topLeft.x, closeTo(0.0, 0.001));
+      expect(result.bottomLeft.x, closeTo(0.0, 0.001));
+    });
+
+    test('lerp: t=0.5 → 중간 값', () {
+      final bubbleRadius = BorderRadius.only(
+        topLeft: const Radius.circular(18),
+        topRight: const Radius.circular(18),
+        bottomLeft: const Radius.circular(4),
+        bottomRight: const Radius.circular(18),
+      );
+      final result = BorderRadius.lerp(bubbleRadius, BorderRadius.zero, 0.5)!;
+      expect(result.topLeft.x, closeTo(9.0, 0.001));
+      expect(result.bottomLeft.x, closeTo(2.0, 0.001));
+    });
+  });
+}


### PR DESCRIPTION
## 개요
디자인 리프레시 6단계 — 이미지 인터랙션을 매끄럽게. 채팅 이미지 탭 시 점프 대신 Hero로 자연스럽게 확대되고, 프로필 이미지 열 때 회색 깜빡임을 제거한다.
⚠️ 스택 PR. base는 `feat/ui-list-entry-haptics`이며 상위 PR 머지 시 자동 retarget.

## 변경 사항
- **이미지 메시지 Hero 전환**: 버블 썸네일 ↔ 풀스크린 뷰어를 `Hero(tag: chat_image_<id>)`로 연결 — 탭하면 제자리에서 확대. drag-to-dismiss/InteractiveViewer 유지.
- **프로필 이미지 캐싱**: 프로필 보기/히스토리/배경의 `Image.network` → `CachedNetworkImage`(placeholder+errorWidget). 매번 회색 깜빡임 제거.

## 검증
- `flutter analyze` → No issues found
- `flutter test` → 전체 1402 통과 (기존 실패 2건은 본 변경과 무관함을 stash 재실행으로 확인). Hero 위젯 테스트는 MessageBubble의 다중 DI 의존으로 생략(사유 PR 코멘트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)