### PR TITLE
feat(ui): 마이크로 인터랙션 — 배너 reveal·리액션·토글 햅틱

### DIFF
--- a/lib/presentation/pages/settings/chat_settings_page.dart
+++ b/lib/presentation/pages/settings/chat_settings_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import '../../../core/router/app_router.dart';
 import '../../../core/theme/app_colors.dart';
+import '../../../core/utils/app_haptics.dart';
 import '../../blocs/settings/chat_settings_cubit.dart';
 import '../../blocs/settings/chat_settings_state.dart';
 
@@ -230,7 +231,10 @@ class _ChatSettingsPageState extends State<ChatSettingsPage> {
       secondary: Icon(icon),
       title: Text(title),
       value: value,
-      onChanged: onChanged,
+      onChanged: (v) {
+        AppHaptics.selection();
+        onChanged(v);
+      },
     );
   }
 

--- a/lib/presentation/pages/settings/notification_settings_page.dart
+++ b/lib/presentation/pages/settings/notification_settings_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import '../../../core/router/app_router.dart';
 import '../../../core/theme/app_colors.dart';
+import '../../../core/utils/app_haptics.dart';
 import '../../../domain/entities/notification_settings.dart';
 import '../../blocs/settings/notification_settings_cubit.dart';
 import '../../blocs/settings/notification_settings_state.dart';
@@ -293,7 +294,10 @@ class _NotificationSettingsPageState extends State<NotificationSettingsPage> {
       title: Text(title),
       subtitle: Text(subtitle),
       value: value,
-      onChanged: onChanged,
+      onChanged: (v) {
+        AppHaptics.selection();
+        onChanged(v);
+      },
     );
   }
 

--- a/lib/presentation/pages/settings/security_settings_page.dart
+++ b/lib/presentation/pages/settings/security_settings_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../../core/utils/app_haptics.dart';
 import '../../blocs/settings/biometric_settings_cubit.dart';
 import '../../blocs/settings/biometric_settings_state.dart';
 
@@ -38,7 +39,10 @@ class SecuritySettingsPage extends StatelessWidget {
                 ),
                 value: state.isEnabled,
                 onChanged: state.isSupported
-                    ? (_) => context.read<BiometricSettingsCubit>().toggle()
+                    ? (_) {
+                        AppHaptics.selection();
+                        context.read<BiometricSettingsCubit>().toggle();
+                      }
                     : null,
               ),
               if (state.isEnabled)

--- a/lib/presentation/pages/settings/settings_page.dart
+++ b/lib/presentation/pages/settings/settings_page.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import '../../../core/router/app_router.dart';
 import '../../../core/theme/app_colors.dart';
+import '../../../core/utils/app_haptics.dart';
 import '../../blocs/auth/auth_bloc.dart';
 import '../../blocs/auth/auth_event.dart';
 import '../../blocs/auth/auth_state.dart';
@@ -127,6 +128,7 @@ class _SettingsPageState extends State<SettingsPage> {
                     trailing: Switch(
                       value: isDark,
                       onChanged: (value) {
+                        AppHaptics.selection();
                         context.read<ThemeCubit>().toggleDarkMode(value);
                       },
                     ),

--- a/lib/presentation/widgets/connection_status_banner.dart
+++ b/lib/presentation/widgets/connection_status_banner.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import '../../core/network/websocket/websocket_events.dart';
+import '../../core/theme/app_motion.dart';
 
 /// Banner widget that displays WebSocket connection status and provides reconnect functionality.
 ///
 /// Shows a warning banner when connection is disconnected or failed, with a retry button.
+/// Animates in/out with a slide+fade so the banner doesn't pop in abruptly.
 class ConnectionStatusBanner extends StatelessWidget {
   final WebSocketConnectionState connectionState;
   final VoidCallback onReconnect;
@@ -14,65 +16,82 @@ class ConnectionStatusBanner extends StatelessWidget {
     required this.onReconnect,
   });
 
+  bool get _isVisible =>
+      connectionState == WebSocketConnectionState.disconnected ||
+      connectionState == WebSocketConnectionState.failed;
+
   @override
   Widget build(BuildContext context) {
-    // Only show banner when disconnected or failed
-    if (connectionState != WebSocketConnectionState.disconnected &&
-        connectionState != WebSocketConnectionState.failed) {
-      return const SizedBox.shrink();
-    }
-
     final backgroundColor = connectionState == WebSocketConnectionState.failed
         ? Colors.red.shade700
         : Colors.orange.shade700;
 
-    return Material(
-      color: backgroundColor,
-      elevation: 4,
-      child: SafeArea(
-        bottom: false,
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          child: Row(
-            children: [
-              Icon(
-                connectionState == WebSocketConnectionState.failed
-                    ? Icons.error_outline
-                    : Icons.wifi_off,
-                color: Colors.white,
-                size: 20,
-              ),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Text(
-                  connectionState == WebSocketConnectionState.failed
-                      ? '연결 실패 - 재시도가 중단되었습니다'
-                      : '연결이 끊어졌습니다',
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontSize: 14,
-                    fontWeight: FontWeight.w500,
+    // AnimatedSize collapses height to 0 when not visible (slide effect).
+    // AnimatedOpacity fades the content so there's no hard pop-in.
+    return AnimatedSize(
+      duration: AppMotion.normal,
+      curve: AppMotion.standard,
+      child: AnimatedOpacity(
+        opacity: _isVisible ? 1.0 : 0.0,
+        duration: AppMotion.normal,
+        curve: AppMotion.standard,
+        child: _isVisible
+            ? Material(
+                color: backgroundColor,
+                elevation: 4,
+                child: SafeArea(
+                  bottom: false,
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    child: Row(
+                      children: [
+                        Icon(
+                          connectionState == WebSocketConnectionState.failed
+                              ? Icons.error_outline
+                              : Icons.wifi_off,
+                          color: Colors.white,
+                          size: 20,
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Text(
+                            connectionState == WebSocketConnectionState.failed
+                                ? '연결 실패 - 재시도가 중단되었습니다'
+                                : '연결이 끊어졌습니다',
+                            style: const TextStyle(
+                              color: Colors.white,
+                              fontSize: 14,
+                              fontWeight: FontWeight.w500,
+                            ),
+                          ),
+                        ),
+                        TextButton.icon(
+                          onPressed: onReconnect,
+                          icon: const Icon(Icons.refresh,
+                              color: Colors.white, size: 18),
+                          label: const Text(
+                            '재연결',
+                            style: TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.bold),
+                          ),
+                          style: TextButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 12, vertical: 8),
+                            backgroundColor:
+                                Colors.white.withValues(alpha: 0.2),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
                 ),
-              ),
-              TextButton.icon(
-                onPressed: onReconnect,
-                icon: const Icon(Icons.refresh, color: Colors.white, size: 18),
-                label: const Text(
-                  '재연결',
-                  style: TextStyle(color: Colors.white, fontWeight: FontWeight.bold),
-                ),
-                style: TextButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                  backgroundColor: Colors.white.withValues(alpha: 0.2),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(8),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
+              )
+            : const SizedBox.shrink(),
       ),
     );
   }

--- a/lib/presentation/widgets/connection_status_banner.dart
+++ b/lib/presentation/widgets/connection_status_banner.dart
@@ -22,13 +22,11 @@ class ConnectionStatusBanner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Guard: only compute per-status values when banner is visible,
-    // avoiding unnecessary branching when the banner is hidden.
-    final backgroundColor = _isVisible
-        ? (connectionState == WebSocketConnectionState.failed
-              ? Colors.red.shade700
-              : Colors.orange.shade700)
-        : null;
+    // Banner background colour. Only consumed inside the `_isVisible`
+    // Material branch below, so it can always be computed non-null.
+    final backgroundColor = connectionState == WebSocketConnectionState.failed
+        ? Colors.red.shade700
+        : Colors.orange.shade700;
 
     // AnimatedSize collapses height to 0 when not visible (slide effect).
     // AnimatedOpacity fades the content so there's no hard pop-in.

--- a/lib/presentation/widgets/connection_status_banner.dart
+++ b/lib/presentation/widgets/connection_status_banner.dart
@@ -22,76 +22,94 @@ class ConnectionStatusBanner extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final backgroundColor = connectionState == WebSocketConnectionState.failed
-        ? Colors.red.shade700
-        : Colors.orange.shade700;
+    // Guard: only compute per-status values when banner is visible,
+    // avoiding unnecessary branching when the banner is hidden.
+    final backgroundColor = _isVisible
+        ? (connectionState == WebSocketConnectionState.failed
+              ? Colors.red.shade700
+              : Colors.orange.shade700)
+        : null;
 
     // AnimatedSize collapses height to 0 when not visible (slide effect).
     // AnimatedOpacity fades the content so there's no hard pop-in.
+    // IgnorePointer prevents the collapsing/hidden banner from intercepting
+    // pointer events on the UI below during the ~250 ms animation window.
     return AnimatedSize(
       duration: AppMotion.normal,
       curve: AppMotion.standard,
-      child: AnimatedOpacity(
-        opacity: _isVisible ? 1.0 : 0.0,
-        duration: AppMotion.normal,
-        curve: AppMotion.standard,
-        child: _isVisible
-            ? Material(
-                color: backgroundColor,
-                elevation: 4,
-                child: SafeArea(
-                  bottom: false,
-                  child: Padding(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                    child: Row(
-                      children: [
-                        Icon(
-                          connectionState == WebSocketConnectionState.failed
-                              ? Icons.error_outline
-                              : Icons.wifi_off,
-                          color: Colors.white,
-                          size: 20,
-                        ),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: Text(
+      child: IgnorePointer(
+        ignoring: !_isVisible,
+        child: AnimatedOpacity(
+          opacity: _isVisible ? 1.0 : 0.0,
+          duration: AppMotion.normal,
+          curve: AppMotion.standard,
+          child: _isVisible
+              ? Material(
+                  color: backgroundColor,
+                  elevation: 4,
+                  child: SafeArea(
+                    bottom: false,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 12,
+                      ),
+                      child: Row(
+                        children: [
+                          Icon(
                             connectionState == WebSocketConnectionState.failed
-                                ? '연결 실패 - 재시도가 중단되었습니다'
-                                : '연결이 끊어졌습니다',
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontSize: 14,
-                              fontWeight: FontWeight.w500,
-                            ),
+                                ? Icons.error_outline
+                                : Icons.wifi_off,
+                            color: Colors.white,
+                            size: 20,
                           ),
-                        ),
-                        TextButton.icon(
-                          onPressed: onReconnect,
-                          icon: const Icon(Icons.refresh,
-                              color: Colors.white, size: 18),
-                          label: const Text(
-                            '재연결',
-                            style: TextStyle(
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: Text(
+                              connectionState == WebSocketConnectionState.failed
+                                  ? '연결 실패 - 재시도가 중단되었습니다'
+                                  : '연결이 끊어졌습니다',
+                              style: const TextStyle(
                                 color: Colors.white,
-                                fontWeight: FontWeight.bold),
-                          ),
-                          style: TextButton.styleFrom(
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 12, vertical: 8),
-                            backgroundColor:
-                                Colors.white.withValues(alpha: 0.2),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(8),
+                                fontSize: 14,
+                                fontWeight: FontWeight.w500,
+                              ),
                             ),
                           ),
-                        ),
-                      ],
+                          TextButton.icon(
+                            onPressed: onReconnect,
+                            icon: const Icon(
+                              Icons.refresh,
+                              color: Colors.white,
+                              size: 18,
+                            ),
+                            label: const Text(
+                              '재연결',
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            style: TextButton.styleFrom(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 12,
+                                vertical: 8,
+                              ),
+                              backgroundColor: Colors.white.withValues(
+                                alpha: 0.2,
+                              ),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
                   ),
-                ),
-              )
-            : const SizedBox.shrink(),
+                )
+              : const SizedBox.shrink(),
+        ),
       ),
     );
   }

--- a/lib/presentation/widgets/reaction_display.dart
+++ b/lib/presentation/widgets/reaction_display.dart
@@ -34,58 +34,65 @@ class ReactionDisplay extends StatelessWidget {
       duration: AppMotion.fast,
       curve: AppMotion.standard,
       child: Padding(
-      padding: EdgeInsets.only(
-        top: 4,
-        left: isMe ? 0 : 44, // Align with message bubble (after avatar)
-      ),
-      child: Wrap(
-        spacing: 4,
-        runSpacing: 4,
-        alignment: isMe ? WrapAlignment.end : WrapAlignment.start,
-        children: grouped.entries.map((entry) {
-          final emoji = entry.key;
-          final reactionList = entry.value;
-          final count = reactionList.length;
-          final hasMyReaction = reactionList.any((r) => r.userId == currentUserId);
+        padding: EdgeInsets.only(
+          top: 4,
+          left: isMe ? 0 : 44, // Align with message bubble (after avatar)
+        ),
+        child: Wrap(
+          spacing: 4,
+          runSpacing: 4,
+          alignment: isMe ? WrapAlignment.end : WrapAlignment.start,
+          children: grouped.entries.map((entry) {
+            final emoji = entry.key;
+            final reactionList = entry.value;
+            final count = reactionList.length;
+            final hasMyReaction = reactionList.any(
+              (r) => r.userId == currentUserId,
+            );
 
-          return GestureDetector(
-            onTap: () {
-              AppHaptics.selection();
-              onReactionTap(emoji);
-            },
-            child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-              decoration: BoxDecoration(
-                color: hasMyReaction
-                    ? AppColors.primary.withValues(alpha: 0.2)
-                    : Colors.grey.withValues(alpha: 0.15),
-                borderRadius: BorderRadius.circular(12),
-                border: hasMyReaction
-                    ? Border.all(color: AppColors.primary.withValues(alpha: 0.5), width: 1)
-                    : null,
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(emoji, style: const TextStyle(fontSize: 14)),
-                  if (count > 1) ...[
-                    const SizedBox(width: 4),
-                    Text(
-                      '$count',
-                      style: TextStyle(
-                        fontSize: 12,
-                        fontWeight: FontWeight.w600,
-                        color: hasMyReaction ? AppColors.primary : Colors.grey[700],
+            return GestureDetector(
+              onTap: () {
+                AppHaptics.selection();
+                onReactionTap(emoji);
+              },
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: hasMyReaction
+                      ? AppColors.primary.withValues(alpha: 0.2)
+                      : Colors.grey.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(12),
+                  border: hasMyReaction
+                      ? Border.all(
+                          color: AppColors.primary.withValues(alpha: 0.5),
+                          width: 1,
+                        )
+                      : null,
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(emoji, style: const TextStyle(fontSize: 14)),
+                    if (count > 1) ...[
+                      const SizedBox(width: 4),
+                      Text(
+                        '$count',
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          color: hasMyReaction
+                              ? AppColors.primary
+                              : Colors.grey[700],
+                        ),
                       ),
-                    ),
+                    ],
                   ],
-                ],
+                ),
               ),
-            ),
-          );
-        }).toList(),
+            );
+          }).toList(),
+        ),
       ),
-    ),
     );
   }
 }

--- a/lib/presentation/widgets/reaction_display.dart
+++ b/lib/presentation/widgets/reaction_display.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../core/theme/app_colors.dart';
+import '../../core/theme/app_motion.dart';
+import '../../core/utils/app_haptics.dart';
 import '../../domain/entities/message.dart';
 
 /// Displays reactions under a message bubble.
@@ -28,7 +30,10 @@ class ReactionDisplay extends StatelessWidget {
       grouped.putIfAbsent(reaction.emoji, () => []).add(reaction);
     }
 
-    return Padding(
+    return AnimatedSize(
+      duration: AppMotion.fast,
+      curve: AppMotion.standard,
+      child: Padding(
       padding: EdgeInsets.only(
         top: 4,
         left: isMe ? 0 : 44, // Align with message bubble (after avatar)
@@ -44,7 +49,10 @@ class ReactionDisplay extends StatelessWidget {
           final hasMyReaction = reactionList.any((r) => r.userId == currentUserId);
 
           return GestureDetector(
-            onTap: () => onReactionTap(emoji),
+            onTap: () {
+              AppHaptics.selection();
+              onReactionTap(emoji);
+            },
             child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
               decoration: BoxDecoration(
@@ -77,6 +85,7 @@ class ReactionDisplay extends StatelessWidget {
           );
         }).toList(),
       ),
+    ),
     );
   }
 }

--- a/test/presentation/widgets/connection_status_banner_test.dart
+++ b/test/presentation/widgets/connection_status_banner_test.dart
@@ -5,7 +5,7 @@ import 'package:co_talk_flutter/presentation/widgets/connection_status_banner.da
 
 void main() {
   group('ConnectionStatusBanner', () {
-    Widget _buildBanner(WebSocketConnectionState state) {
+    Widget buildBanner(WebSocketConnectionState state) {
       return MaterialApp(
         home: Scaffold(
           body: ConnectionStatusBanner(
@@ -18,7 +18,7 @@ void main() {
 
     testWidgets('disconnected 상태에서 배너 콘텐츠가 렌더링된다', (tester) async {
       await tester.pumpWidget(
-        _buildBanner(WebSocketConnectionState.disconnected),
+        buildBanner(WebSocketConnectionState.disconnected),
       );
       await tester.pump(const Duration(milliseconds: 300));
 
@@ -27,27 +27,39 @@ void main() {
     });
 
     testWidgets('failed 상태에서 배너 콘텐츠가 렌더링된다', (tester) async {
-      await tester.pumpWidget(
-        _buildBanner(WebSocketConnectionState.failed),
-      );
+      await tester.pumpWidget(buildBanner(WebSocketConnectionState.failed));
       await tester.pump(const Duration(milliseconds: 300));
 
       expect(find.text('연결 실패 - 재시도가 중단되었습니다'), findsOneWidget);
     });
 
-    testWidgets('connected 상태에서는 배너 콘텐츠가 없다', (tester) async {
-      await tester.pumpWidget(
-        _buildBanner(WebSocketConnectionState.connected),
-      );
-      await tester.pump(const Duration(milliseconds: 300));
+    testWidgets('connected 상태에서는 배너 콘텐츠가 없고 높이가 0으로 접힌다', (tester) async {
+      await tester.pumpWidget(buildBanner(WebSocketConnectionState.connected));
+      await tester.pumpAndSettle();
 
       expect(find.text('연결이 끊어졌습니다'), findsNothing);
       expect(find.text('연결 실패 - 재시도가 중단되었습니다'), findsNothing);
+
+      // AnimatedSize가 완전히 접혀 높이가 0이어야 한다
+      final animatedSize = tester.renderObject<RenderBox>(
+        find.byType(AnimatedSize),
+      );
+      expect(animatedSize.size.height, equals(0.0));
+
+      // IgnorePointer가 활성화되어 포인터 이벤트를 차단해야 한다.
+      // AnimatedSize 내부에서 첫 번째로 발견되는 IgnorePointer가 우리 것이다.
+      final ignorePointer = tester.widget<IgnorePointer>(
+        find.descendant(
+          of: find.byType(AnimatedSize),
+          matching: find.byType(IgnorePointer),
+        ),
+      );
+      expect(ignorePointer.ignoring, isTrue);
     });
 
     testWidgets('위젯 트리에 AnimatedSize와 AnimatedOpacity가 존재한다', (tester) async {
       await tester.pumpWidget(
-        _buildBanner(WebSocketConnectionState.disconnected),
+        buildBanner(WebSocketConnectionState.disconnected),
       );
       await tester.pump(const Duration(milliseconds: 300));
 

--- a/test/presentation/widgets/connection_status_banner_test.dart
+++ b/test/presentation/widgets/connection_status_banner_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:co_talk_flutter/core/network/websocket/websocket_events.dart';
+import 'package:co_talk_flutter/presentation/widgets/connection_status_banner.dart';
+
+void main() {
+  group('ConnectionStatusBanner', () {
+    Widget _buildBanner(WebSocketConnectionState state) {
+      return MaterialApp(
+        home: Scaffold(
+          body: ConnectionStatusBanner(
+            connectionState: state,
+            onReconnect: () {},
+          ),
+        ),
+      );
+    }
+
+    testWidgets('disconnected 상태에서 배너 콘텐츠가 렌더링된다', (tester) async {
+      await tester.pumpWidget(
+        _buildBanner(WebSocketConnectionState.disconnected),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text('연결이 끊어졌습니다'), findsOneWidget);
+      expect(find.text('재연결'), findsOneWidget);
+    });
+
+    testWidgets('failed 상태에서 배너 콘텐츠가 렌더링된다', (tester) async {
+      await tester.pumpWidget(
+        _buildBanner(WebSocketConnectionState.failed),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text('연결 실패 - 재시도가 중단되었습니다'), findsOneWidget);
+    });
+
+    testWidgets('connected 상태에서는 배너 콘텐츠가 없다', (tester) async {
+      await tester.pumpWidget(
+        _buildBanner(WebSocketConnectionState.connected),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.text('연결이 끊어졌습니다'), findsNothing);
+      expect(find.text('연결 실패 - 재시도가 중단되었습니다'), findsNothing);
+    });
+
+    testWidgets('위젯 트리에 AnimatedSize와 AnimatedOpacity가 존재한다', (tester) async {
+      await tester.pumpWidget(
+        _buildBanner(WebSocketConnectionState.disconnected),
+      );
+      await tester.pump(const Duration(milliseconds: 300));
+
+      expect(find.byType(AnimatedSize), findsOneWidget);
+      expect(find.byType(AnimatedOpacity), findsOneWidget);
+    });
+  });
+}

--- a/test/presentation/widgets/reaction_display_test.dart
+++ b/test/presentation/widgets/reaction_display_test.dart
@@ -14,9 +14,9 @@ void main() {
       calls.clear();
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.platform, (call) async {
-        calls.add(call);
-        return null;
-      });
+            calls.add(call);
+            return null;
+          });
     });
 
     tearDown(() {
@@ -24,26 +24,19 @@ void main() {
           .setMockMethodCallHandler(SystemChannels.platform, null);
     });
 
-    List<MessageReaction> _reactions(String emoji, int userId) => [
-          MessageReaction(
-            id: 1,
-            messageId: 10,
-            userId: userId,
-            emoji: emoji,
-          ),
-        ];
+    List<MessageReaction> buildReactions(String emoji, int userId) => [
+      MessageReaction(id: 1, messageId: 10, userId: userId, emoji: emoji),
+    ];
 
     testWidgets('리액션 탭 시 selectionClick 햅틱이 발생한다', (tester) async {
-      String? tappedEmoji;
-
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
             body: ReactionDisplay(
-              reactions: _reactions('👍', 1),
+              reactions: buildReactions('👍', 1),
               currentUserId: 1,
               isMe: false,
-              onReactionTap: (emoji) => tappedEmoji = emoji,
+              onReactionTap: (_) {},
             ),
           ),
         ),
@@ -52,12 +45,16 @@ void main() {
       await tester.tap(find.text('👍'));
       await tester.pump();
 
-      // 햅틱 호출 검증
+      // 햅틱 호출 검증: 정확히 1회만 발생해야 한다 (double-fire 방지)
       expect(
-        calls.any((c) =>
-            c.method == 'HapticFeedback.vibrate' &&
-            c.arguments == 'HapticFeedbackType.selectionClick'),
-        isTrue,
+        calls
+            .where(
+              (c) =>
+                  c.method == 'HapticFeedback.vibrate' &&
+                  c.arguments == 'HapticFeedbackType.selectionClick',
+            )
+            .length,
+        equals(1),
       );
     });
 
@@ -68,7 +65,7 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: ReactionDisplay(
-              reactions: _reactions('❤️', 2),
+              reactions: buildReactions('❤️', 2),
               currentUserId: 1,
               isMe: true,
               onReactionTap: (emoji) => tappedEmoji = emoji,
@@ -88,7 +85,7 @@ void main() {
         MaterialApp(
           home: Scaffold(
             body: ReactionDisplay(
-              reactions: _reactions('😂', 3),
+              reactions: buildReactions('😂', 3),
               currentUserId: 1,
               isMe: false,
               onReactionTap: (_) {},

--- a/test/presentation/widgets/reaction_display_test.dart
+++ b/test/presentation/widgets/reaction_display_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:co_talk_flutter/domain/entities/message.dart';
+import 'package:co_talk_flutter/presentation/widgets/reaction_display.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('ReactionDisplay', () {
+    final calls = <MethodCall>[];
+
+    setUp(() {
+      calls.clear();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        calls.add(call);
+        return null;
+      });
+    });
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+    });
+
+    List<MessageReaction> _reactions(String emoji, int userId) => [
+          MessageReaction(
+            id: 1,
+            messageId: 10,
+            userId: userId,
+            emoji: emoji,
+          ),
+        ];
+
+    testWidgets('리액션 탭 시 selectionClick 햅틱이 발생한다', (tester) async {
+      String? tappedEmoji;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ReactionDisplay(
+              reactions: _reactions('👍', 1),
+              currentUserId: 1,
+              isMe: false,
+              onReactionTap: (emoji) => tappedEmoji = emoji,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('👍'));
+      await tester.pump();
+
+      // 햅틱 호출 검증
+      expect(
+        calls.any((c) =>
+            c.method == 'HapticFeedback.vibrate' &&
+            c.arguments == 'HapticFeedbackType.selectionClick'),
+        isTrue,
+      );
+    });
+
+    testWidgets('리액션 탭 시 onReactionTap 콜백이 호출된다', (tester) async {
+      String? tappedEmoji;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ReactionDisplay(
+              reactions: _reactions('❤️', 2),
+              currentUserId: 1,
+              isMe: true,
+              onReactionTap: (emoji) => tappedEmoji = emoji,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('❤️'));
+      await tester.pump();
+
+      expect(tappedEmoji, '❤️');
+    });
+
+    testWidgets('위젯 트리에 AnimatedSize가 존재한다', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ReactionDisplay(
+              reactions: _reactions('😂', 3),
+              currentUserId: 1,
+              isMe: false,
+              onReactionTap: (_) {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(AnimatedSize), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## 개요
디자인 리프레시 7단계(마지막 폴리시) — 자잘하지만 체감되는 마이크로 인터랙션을 다듬는다.
⚠️ 스택 PR. base는 `feat/ui-media-images`이며 상위 PR 머지 시 자동 retarget.

## 변경 사항
- **연결 상태 배너 reveal**: 즉시 나타나고 사라지던 배너 → `AnimatedSize`+`AnimatedOpacity`로 슬라이드/페이드. 레이아웃 점프 제거.
- **리액션 햅틱 + 부드러운 추가/제거**: 리액션 탭 시 `AppHaptics.selection()`, `Wrap`을 `AnimatedSize`로 감싸 추가/제거 시 부드럽게 리사이즈.
- **설정 토글 햅틱**: 다크모드·생체인증·채팅(미디어 자동 다운로드 6개)·알림(6개) 등 14개 스위치 토글에 `AppHaptics.selection()`.

## 검증
- `flutter analyze` → 신규 이슈 없음 (notification_settings의 RadioListTile deprecation info 2건은 기존 기술부채)
- `flutter test` → 16/16 통과 (배너 4 / 리액션 3 / 설정 9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)