### PR TITLE
fix(test): UI 리프레시 머지 후 깨진 위젯 테스트 4건 복구 (로딩 스켈레톤·프로필 이미지)

### DIFF
--- a/test/pages/chat_list_page_test.dart
+++ b/test/pages/chat_list_page_test.dart
@@ -10,6 +10,7 @@ import 'package:co_talk_flutter/presentation/blocs/chat/chat_list_bloc.dart';
 import 'package:co_talk_flutter/presentation/blocs/chat/chat_list_event.dart';
 import 'package:co_talk_flutter/presentation/blocs/chat/chat_list_state.dart';
 import 'package:co_talk_flutter/presentation/pages/chat/chat_list_page.dart';
+import 'package:co_talk_flutter/presentation/widgets/skeletons/list_skeleton.dart';
 import 'package:co_talk_flutter/domain/entities/chat_room.dart';
 import 'package:co_talk_flutter/domain/entities/user.dart';
 import 'package:intl/date_symbol_data_local.dart';
@@ -70,7 +71,7 @@ void main() {
 
       await tester.pumpWidget(createWidgetUnderTest());
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(ListSkeleton), findsOneWidget);
     });
 
     testWidgets('shows empty message when no chat rooms', (tester) async {

--- a/test/pages/chat_list_page_test.dart
+++ b/test/pages/chat_list_page_test.dart
@@ -64,7 +64,7 @@ void main() {
       expect(find.text('채팅'), findsOneWidget);
     });
 
-    testWidgets('shows loading indicator when loading', (tester) async {
+    testWidgets('shows loading skeleton when loading', (tester) async {
       when(() => mockChatListBloc.state).thenReturn(
         const ChatListState(status: ChatListStatus.loading),
       );

--- a/test/pages/edit_profile_page_test.dart
+++ b/test/pages/edit_profile_page_test.dart
@@ -358,8 +358,17 @@ void main() {
     group('Success State', () {
       testWidgets('shows success snackbar when profile update succeeds',
           (tester) async {
-        when(() => mockAuthBloc.state).thenReturn(
-          AuthState.authenticated(testUser),
+        // 초기 상태는 authenticated(폼 렌더링), 이후 stream 으로
+        // loading -> authenticated 전이를 emit 해 AuthBloc BlocListener
+        // (edit_profile_page.dart:385~)의 success 경로를 발화시킨다.
+        final updatedUser = testUser.copyWith(nickname: 'NewNickname');
+        whenListen(
+          mockAuthBloc,
+          Stream<AuthState>.fromIterable([
+            const AuthState(status: AuthStatus.loading),
+            AuthState.authenticated(updatedUser),
+          ]),
+          initialState: AuthState.authenticated(testUser),
         );
         when(() => mockProfileBloc.state).thenReturn(
           const ProfileState.initial(),
@@ -367,27 +376,32 @@ void main() {
 
         await tester.pumpWidget(createWidgetUnderTest());
 
-        // Simulate state change to success
-        when(() => mockAuthBloc.state).thenReturn(
-          AuthState.authenticated(testUser.copyWith(nickname: 'NewNickname')),
-        );
-        mockAuthBloc.stream.listen((state) {});
-
         // CachedNetworkImage(BackgroundImageSection)의 placeholder는 테스트
         // 환경에서 무한 pending이라 pumpAndSettle 이 타임아웃된다.
         // 파일 내 다른 테스트와 동일하게 유한 pump 로 프레임을 진행한다.
         await tester.pump(const Duration(milliseconds: 300));
 
-        // Note: Snackbar test requires more complex setup with ScaffoldMessenger
-        // Skipping actual snackbar verification, but structure is tested
+        // showSuccessSnackbar 가 띄운 SnackBar 와 실제 문구('프로필이 수정되었습니다')를 검증.
+        expect(find.byType(SnackBar), findsOneWidget);
+        expect(find.text('프로필이 수정되었습니다'), findsOneWidget);
       });
     });
 
     group('Error State', () {
       testWidgets('shows error snackbar when profile update fails',
           (tester) async {
-        when(() => mockAuthBloc.state).thenReturn(
-          AuthState.authenticated(testUser),
+        // 초기 authenticated 이후 stream 으로 loading -> failure 전이를 emit 해
+        // AuthBloc BlocListener(edit_profile_page.dart:401~)의 showErrorSnackbar 를 발화.
+        whenListen(
+          mockAuthBloc,
+          Stream<AuthState>.fromIterable([
+            const AuthState(status: AuthStatus.loading),
+            const AuthState(
+              status: AuthStatus.failure,
+              errorMessage: 'Update failed',
+            ),
+          ]),
+          initialState: AuthState.authenticated(testUser),
         );
         when(() => mockProfileBloc.state).thenReturn(
           const ProfileState.initial(),
@@ -395,20 +409,14 @@ void main() {
 
         await tester.pumpWidget(createWidgetUnderTest());
 
-        // Simulate state change to failure
-        when(() => mockAuthBloc.state).thenReturn(
-          const AuthState(
-            status: AuthStatus.failure,
-            errorMessage: 'Update failed',
-          ),
-        );
-
         // CachedNetworkImage(BackgroundImageSection)의 placeholder는 테스트
         // 환경에서 무한 pending이라 pumpAndSettle 이 타임아웃된다.
         // 파일 내 다른 테스트와 동일하게 유한 pump 로 프레임을 진행한다.
         await tester.pump(const Duration(milliseconds: 300));
 
-        // Error handling tested via state management
+        // showErrorSnackbar 가 state.errorMessage 를 그대로 노출하는지 검증.
+        expect(find.byType(SnackBar), findsOneWidget);
+        expect(find.text('Update failed'), findsOneWidget);
       });
     });
 

--- a/test/pages/edit_profile_page_test.dart
+++ b/test/pages/edit_profile_page_test.dart
@@ -373,7 +373,10 @@ void main() {
         );
         mockAuthBloc.stream.listen((state) {});
 
-        await tester.pumpAndSettle();
+        // CachedNetworkImage(BackgroundImageSection)의 placeholder는 테스트
+        // 환경에서 무한 pending이라 pumpAndSettle 이 타임아웃된다.
+        // 파일 내 다른 테스트와 동일하게 유한 pump 로 프레임을 진행한다.
+        await tester.pump(const Duration(milliseconds: 300));
 
         // Note: Snackbar test requires more complex setup with ScaffoldMessenger
         // Skipping actual snackbar verification, but structure is tested
@@ -400,7 +403,10 @@ void main() {
           ),
         );
 
-        await tester.pumpAndSettle();
+        // CachedNetworkImage(BackgroundImageSection)의 placeholder는 테스트
+        // 환경에서 무한 pending이라 pumpAndSettle 이 타임아웃된다.
+        // 파일 내 다른 테스트와 동일하게 유한 pump 로 프레임을 진행한다.
+        await tester.pump(const Duration(milliseconds: 300));
 
         // Error handling tested via state management
       });

--- a/test/pages/friend_list_page_test.dart
+++ b/test/pages/friend_list_page_test.dart
@@ -78,12 +78,17 @@ void main() {
       expect(find.text('친구'), findsOneWidget);
     });
 
-    testWidgets('shows loading indicator when loading', (tester) async {
+    testWidgets('shows loading skeleton when loading', (tester) async {
       await tester.pumpWidget(createWidgetUnderTest(
         friendState: const FriendState(status: FriendStatus.loading),
       ));
 
       expect(find.byType(ListSkeleton), findsOneWidget);
+      // 친구 화면 스켈레톤은 친구 아바타 지름(70)에 맞춰야 한다(화면별 회귀 방지).
+      expect(
+        tester.widget<ListSkeleton>(find.byType(ListSkeleton)).avatarSize,
+        70,
+      );
     });
 
     testWidgets('shows empty message when no friends', (tester) async {

--- a/test/pages/friend_list_page_test.dart
+++ b/test/pages/friend_list_page_test.dart
@@ -9,6 +9,7 @@ import 'package:co_talk_flutter/presentation/blocs/friend/friend_state.dart';
 import 'package:co_talk_flutter/presentation/blocs/auth/auth_bloc.dart';
 import 'package:co_talk_flutter/presentation/blocs/auth/auth_state.dart';
 import 'package:co_talk_flutter/presentation/pages/friends/friend_list_page.dart';
+import 'package:co_talk_flutter/presentation/widgets/skeletons/list_skeleton.dart';
 import 'package:co_talk_flutter/domain/entities/friend.dart';
 import 'package:co_talk_flutter/domain/entities/user.dart';
 
@@ -82,7 +83,7 @@ void main() {
         friendState: const FriendState(status: FriendStatus.loading),
       ));
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(ListSkeleton), findsOneWidget);
     });
 
     testWidgets('shows empty message when no friends', (tester) async {


### PR DESCRIPTION
## 배경
최근 UI 리프레시 PR(#64 목록 로딩 shimmer 스켈레톤, #67 프로필 이미지 CachedNetworkImage 캐싱)이 main에 머지된 뒤 `flutter test` 전체에서 기존 위젯 테스트 4건이 실패했다. 해당 테스트들은 각 PR diff에 포함되지 않은 기존 테스트라 코드리뷰로는 잡히지 않았다.

## 실패 4건과 근본 원인
1. `test/pages/chat_list_page_test.dart` — "shows loading indicator when loading"
2. `test/pages/friend_list_page_test.dart` — "shows loading indicator when loading"
   - 원인(테스트 미갱신): #64가 로딩 상태를 `CircularProgressIndicator` → `ListSkeleton`(shimmer) 으로 의도적으로 교체했으나 테스트는 여전히 `CircularProgressIndicator` 를 찾고 있었다.
3. `test/pages/edit_profile_page_test.dart` — "shows success snackbar when profile update succeeds"
4. `test/pages/edit_profile_page_test.dart` — "shows error snackbar when profile update fails"
   - 원인(테스트 미갱신): #67이 `BackgroundImageSection` 에 도입한 `CachedNetworkImage` 는 테스트의 `_TestHttpOverrides`(dart:io HttpClient) 를 거치지 않아 placeholder가 무한 pending → `pumpAndSettle()` 타임아웃.

4건 모두 프로덕션 회귀가 아니라 의도된 UI 변경에 테스트가 따라가지 못한 케이스다.

## 변경
- 로딩 단언 2건: `find.byType(CircularProgressIndicator)` → `find.byType(ListSkeleton)` 로 갱신(+ import 추가). 로딩 상태가 실제로 스켈레톤으로 표시됨을 의미있게 검증.
- edit_profile 2건: `pumpAndSettle()` → 파일 내 다른 테스트와 동일한 유한 `pump(Duration(...))` 로 교체해 무한대기 해소.

## 검증
- 해당 테스트 그린: chat_list / friend_list / edit_profile 모두 통과
- `flutter analyze`: No issues found
- `flutter test` 전체: +1744 통과, 실패 0 (기존 skip 2건 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)