### PR TITLE
fix(chat): ChatRoomBloc 생명주기 안전성 — emit-after-close 크래시 및 activeRoom race 해소

### DIFF
--- a/lib/presentation/blocs/chat/chat_room_bloc.dart
+++ b/lib/presentation/blocs/chat/chat_room_bloc.dart
@@ -165,6 +165,7 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
 
     // 1. Load cached messages first (fast initial display)
     final cachedMessages = await _cacheManager.loadCachedMessages(event.roomId);
+    if (isClosed) return;
     if (cachedMessages.isNotEmpty) {
       emit(state.copyWith(
         status: ChatRoomStatus.success,
@@ -196,6 +197,8 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
       _log('Fetched ${_cacheManager.messages.length} messages from server');
 
       await _subscribeToWebSocket(event.roomId);
+
+      if (isClosed) return;
 
       // Subscribe to reconnection events for gap recovery
       _reconnectedSubscription?.cancel();
@@ -230,6 +233,7 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
         if (state.currentUserId != null) {
           _presenceManager.sendPresenceActive(event.roomId, state.currentUserId!);
           await _messageHandler.markAsRead(event.roomId);
+          if (isClosed) return;
           emit(state.copyWith(isReadMarked: true));
         }
       } else if (state.currentUserId != null && !_presenceManager.isViewingRoom) {
@@ -239,6 +243,8 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
       }
     } catch (e, stackTrace) {
       _log('Error in _onOpened: $e\n$stackTrace');
+
+      if (isClosed) return;
 
       // Offline mode: keep cached messages if available
       if (state.messages.isNotEmpty) {
@@ -437,6 +443,7 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
     _log('_onRefreshRequested: performing gap recovery for room ${state.roomId}');
 
     final hasNewMessages = await _cacheManager.refreshFromServer(state.roomId!);
+    if (isClosed) return;
     if (hasNewMessages) {
       final latestId = _cacheManager.lastMessageId;
       if (latestId != null) {
@@ -454,6 +461,7 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
 
     if (state.currentUserId != null && _presenceManager.isViewingRoom) {
       await _messageHandler.markAsRead(state.roomId!);
+      if (isClosed) return;
       emit(state.copyWith(isReadMarked: true));
     }
   }
@@ -584,6 +592,7 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
     // Presence active + mark as read (both mobile and desktop)
     _presenceManager.sendPresenceActive(state.roomId!, state.currentUserId!);
     await _messageHandler.markAsRead(state.roomId!);
+    if (isClosed) return;
 
     // Emit updated state
     final newCursor = _cacheManager.nextCursor;
@@ -618,8 +627,10 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
     emit(state.copyWith(isForwarding: true, forwardSuccess: false));
     try {
       await _chatRepository.forwardMessage(event.messageId, event.targetRoomId);
+      if (isClosed) return;
       emit(state.copyWith(isForwarding: false, forwardSuccess: true));
     } catch (e) {
+      if (isClosed) return;
       emit(state.copyWith(
         isForwarding: false,
         forwardSuccess: false,
@@ -694,6 +705,7 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
 
     try {
       final messages = await _cacheManager.loadMoreMessages(state.roomId!);
+      if (isClosed) return;
       emit(state.copyWith(
         messages: messages,
         nextCursor: _cacheManager.nextCursor,
@@ -701,6 +713,7 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
         isLoadingMore: false,
       ));
     } catch (e) {
+      if (isClosed) return;
       emit(state.copyWith(
         errorMessage: e.toString(),
         isLoadingMore: false,
@@ -902,10 +915,12 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
 
     try {
       await _messageHandler.deleteMessage(event.messageId);
+      if (isClosed) return;
       _cacheManager.markMessageAsDeleted(event.messageId);
 
       emit(state.copyWith(messages: _cacheManager.messages));
     } catch (e) {
+      if (isClosed) return;
       emit(state.copyWith(errorMessage: e.toString()));
     }
   }
@@ -1106,6 +1121,7 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
         messageId: event.messageId,
         content: event.content,
       );
+      if (isClosed) return;
 
       _cacheManager.updateMessage(
         event.messageId,
@@ -1114,6 +1130,7 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
 
       emit(state.copyWith(messages: _cacheManager.messages));
     } catch (e) {
+      if (isClosed) return;
       emit(state.copyWith(errorMessage: e.toString()));
     }
   }
@@ -1127,8 +1144,10 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
 
     try {
       await _messageHandler.leaveChatRoom(roomId);
+      if (isClosed) return;
       emit(state.copyWith(hasLeft: true));
     } catch (e) {
+      if (isClosed) return;
       emit(state.copyWith(errorMessage: e.toString()));
     }
   }
@@ -1147,6 +1166,7 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
         roomId: roomId,
         inviteeId: event.inviteeId,
       );
+      if (isClosed) return;
       emit(state.copyWith(
         isReinviting: false,
         reinviteSuccess: true,
@@ -1154,6 +1174,7 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
       ));
       _log('User reinvited: inviteeId=${event.inviteeId}');
     } catch (e) {
+      if (isClosed) return;
       emit(state.copyWith(
         isReinviting: false,
         reinviteSuccess: false,
@@ -1189,16 +1210,21 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
         roomId: state.roomId!,
         filePath: event.filePath,
         onProgress: (progress) {
+          // Upload progress callbacks can fire after the user leaves the room
+          // (bloc closed mid-upload). Guard against emit-after-close crashes.
+          if (isClosed) return;
           emit(state.copyWith(uploadProgress: progress));
         },
       );
 
+      if (isClosed) return;
       emit(state.copyWith(
         isUploadingFile: false,
         uploadProgress: 1.0,
       ));
     } catch (e) {
       _log('File attachment failed: $e');
+      if (isClosed) return;
       final raw = e.toString().toLowerCase();
       final isSignatureError = raw.contains('signature') ||
           raw.contains('content type') ||

--- a/lib/presentation/blocs/chat/chat_room_bloc.dart
+++ b/lib/presentation/blocs/chat/chat_room_bloc.dart
@@ -399,10 +399,21 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
     _roomInitialized = false;
     _pendingForegrounded = false;
 
-    // Release notification suppression
-    _desktopNotificationBridge.setActiveRoomId(null);
-    _activeRoomTracker.activeRoomId = null;
-    _log('_onClosed: activeRoomId cleared for notification suppression');
+    // Release notification suppression.
+    // Ownership guard: only clear if the active room is still THIS room.
+    // On fast A->B room switches, B's ChatRoomOpened may have already set
+    // activeRoomId=B before A's _onClosed runs; clearing unconditionally would
+    // wipe B's active state and break notification suppression for B.
+    final closingRoomId = state.roomId;
+    if (closingRoomId != null) {
+      if (_desktopNotificationBridge.activeRoomId == closingRoomId) {
+        _desktopNotificationBridge.setActiveRoomId(null);
+      }
+      if (_activeRoomTracker.activeRoomId == closingRoomId) {
+        _activeRoomTracker.activeRoomId = null;
+      }
+    }
+    _log('_onClosed: activeRoomId cleared for notification suppression (room=$closingRoomId)');
 
     emit(const ChatRoomState());
   }

--- a/lib/presentation/blocs/chat/chat_room_bloc.dart
+++ b/lib/presentation/blocs/chat/chat_room_bloc.dart
@@ -603,6 +603,10 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
     // Presence active + mark as read (both mobile and desktop)
     _presenceManager.sendPresenceActive(state.roomId!, state.currentUserId!);
     await _messageHandler.markAsRead(state.roomId!);
+    // 가드 주의: 이 핸들러는 emit이 말미 1곳뿐이라 이 단일 가드로 충분하다.
+    // 위쪽 await들(_subscribeToWebSocket / refreshFromServer / markAsRead 등)과
+    // 이 지점 사이에 새 emit을 추가할 경우, 해당 emit 직전마다 별도의
+    // `if (isClosed) return;` 가드를 반드시 넣어야 emit-after-close를 막을 수 있다.
     if (isClosed) return;
 
     // Emit updated state

--- a/lib/presentation/pages/chat/chat_room_page.dart
+++ b/lib/presentation/pages/chat/chat_room_page.dart
@@ -291,9 +291,14 @@ class _ChatRoomPageState extends State<ChatRoomPage> with WidgetsBindingObserver
     _scrollController.dispose();
 
     // ActiveRoomTracker를 동기적으로 즉시 해제 (FCM 알림 suppress 방지)
+    // 소유권 가드: 방 A->B 빠른 전환 시 B의 initState가 이미 activeRoomId=B로
+    // 설정했을 수 있으므로, 현재 활성 방이 "내 방"일 때만 해제한다.
+    // 무조건 null로 덮어쓰면 B의 active 설정이 지워져 B 알림 억제가 깨진다.
     try {
       final activeRoomTracker = GetIt.instance<ActiveRoomTracker>();
-      activeRoomTracker.activeRoomId = null;
+      if (activeRoomTracker.activeRoomId == widget.roomId) {
+        activeRoomTracker.activeRoomId = null;
+      }
     } catch (_) {}
 
     if (!_chatRoomBloc.isClosed) {

--- a/test/blocs/chat_room_bloc_test.dart
+++ b/test/blocs/chat_room_bloc_test.dart
@@ -4053,11 +4053,57 @@ void main() {
 
         // emit-after-close는 bloc 버전에 따라 StateError 또는 AssertionError로
         // 표면화된다. 어떤 종류든 uncaught error가 없어야 한다.
+        //
+        // 주의(항진성 한계): bloc 8.1.4의 emit은 emitter가 canceled(close 후)
+        // 상태이면 StateError를 던지지 않고 silent no-op으로 처리한다. 따라서
+        // 이 `errors isEmpty` 단언만으로는 "가드가 동작함"을 증명하지 못하며,
+        // 가드를 제거해도 그린으로 통과한다. 가드의 실제 효과(close 후 분기
+        // 스킵)를 검증하는 회귀 가드는 아래의 별도 테스트
+        // ('가드가 close 후 후속 분기를 실제로 스킵한다')에서 다룬다.
         expect(
           errors,
           isEmpty,
           reason: 'await 이후 emit 가드가 없으면 emit-after-close 크래시 발생',
         );
+      });
+
+      test(
+          'P1(회귀가드): _onOpened의 await 도중 close()되면 emit 이후 분기가 실제로 스킵된다',
+          () async {
+        // bloc 8.1.4의 emit은 close 후 no-op이라 "state가 안 바뀜"만으로는
+        // 가드 효과를 증명하지 못한다(항진적). 대신 가드(`if (isClosed) return;`,
+        // chat_room_bloc.dart:201)가 막아주는 *emit과 무관한 관찰가능 부수효과*를
+        // 단언한다. 가드 직후 라인(205)은 `_webSocketService.reconnected`에
+        // 접근해 .listen() 구독을 건다. close 도중 서버 sync await가 풀리면:
+        //   - 가드가 있으면: 201에서 early-return → reconnected 접근 없음.
+        //   - 가드를 제거하면: 205가 실행 → reconnected 접근 발생.
+        // 즉 verifyNever(reconnected)는 가드 제거 시 RED가 되어 의미가 있다.
+        final completer = Completer<(List<Message>, int?, bool)>();
+        when(() => mockChatRepository.getMessages(any(), size: any(named: 'size')))
+            .thenAnswer((_) => completer.future);
+        when(() => mockChatRepository.markAsRead(any())).thenAnswer((_) async {});
+
+        await runCapturingErrors(() async {
+          final bloc = createBloc();
+          bloc.add(const ChatRoomOpened(1));
+          // loading emit 후 서버 sync await(getMessages)에 진입할 때까지 진행.
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+
+          // 아직 close 전에는 reconnected 구독이 일어나선 안 된다(사전 조건).
+          verifyNever(() => mockWebSocketService.reconnected);
+
+          // await 도중 close.
+          await bloc.close();
+          expect(bloc.isClosed, isTrue);
+
+          // 서버 응답 도착 → await가 풀린다. 가드가 있으면 여기서 early-return.
+          completer.complete((<Message>[], null, false));
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+        });
+
+        // 가드가 동작하면 close 이후 라인 205(reconnected.listen)에 절대
+        // 도달하지 않는다. 가드를 제거하면 이 단언이 실패(RED)한다.
+        verifyNever(() => mockWebSocketService.reconnected);
       });
 
       test(

--- a/test/blocs/chat_room_bloc_test.dart
+++ b/test/blocs/chat_room_bloc_test.dart
@@ -4000,5 +4000,157 @@ void main() {
         ],
       );
     });
+
+    // ============================================================
+    // Lifecycle safety: emit-after-close & activeRoom race
+    // ============================================================
+    group('생명주기 안전성 (emit-after-close 가드)', () {
+      // emit-after-close는 Bloc 핸들러 내부에서 StateError를 throw하고,
+      // Bloc.onError -> Zone.handleUncaughtError로 전파된다. 가드가 없으면
+      // 이 zone 에러가 잡힌다. runZonedGuarded로 캡처해 단언한다.
+      Future<List<Object>> runCapturingErrors(
+        Future<void> Function() body,
+      ) async {
+        final errors = <Object>[];
+        final done = Completer<void>();
+        runZonedGuarded(() async {
+          await body();
+          done.complete();
+        }, (error, stack) {
+          errors.add(error);
+          if (!done.isCompleted) done.complete();
+        });
+        await done.future;
+        // 비동기 emit-after-close가 늦게 도착할 수 있어 한 틱 더 기다린다.
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        return errors;
+      }
+
+      test(
+          'P1: ChatRoomOpened의 await 도중 close()되어도 emit-after-close StateError가 없다',
+          () async {
+        final errors = await runCapturingErrors(() async {
+          // getMessages를 느리게 만들어 서버 sync await 도중 close를 끼워넣는다.
+          final completer = Completer<(List<Message>, int?, bool)>();
+          when(() => mockChatRepository.getMessages(any(), size: any(named: 'size')))
+              .thenAnswer((_) => completer.future);
+          when(() => mockChatRepository.markAsRead(any())).thenAnswer((_) async {});
+
+          final bloc = createBloc();
+          bloc.add(const ChatRoomOpened(1));
+          // loading emit까지 진행시키고 서버 sync await에 진입하게 한다.
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+
+          // await 도중 방을 빠르게 나가 bloc을 close.
+          await bloc.close();
+          expect(bloc.isClosed, isTrue);
+
+          // 이제 서버 응답이 도착해 await가 풀린다 → 가드가 없으면 emit-after-close 크래시.
+          completer.complete((<Message>[], null, false));
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+        });
+
+        // emit-after-close는 bloc 버전에 따라 StateError 또는 AssertionError로
+        // 표면화된다. 어떤 종류든 uncaught error가 없어야 한다.
+        expect(
+          errors,
+          isEmpty,
+          reason: 'await 이후 emit 가드가 없으면 emit-after-close 크래시 발생',
+        );
+      });
+
+      test(
+          'P1: _onRefreshRequested의 await 도중 close()되어도 emit-after-close StateError가 없다',
+          () async {
+        final errors = await runCapturingErrors(() async {
+          when(() => mockChatRepository.getMessages(any(), size: any(named: 'size')))
+              .thenAnswer((_) async => (<Message>[], null, false));
+          when(() => mockChatRepository.markAsRead(any())).thenAnswer((_) async {});
+
+          final bloc = createBloc();
+          bloc.add(const ChatRoomOpened(1));
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+
+          // refresh의 첫 await(getMessages)를 느리게 만든다.
+          final completer = Completer<(List<Message>, int?, bool)>();
+          when(() => mockChatRepository.getMessages(
+                any(),
+                size: any(named: 'size'),
+                beforeMessageId: any(named: 'beforeMessageId'),
+              )).thenAnswer((_) => completer.future);
+
+          bloc.add(const ChatRoomRefreshRequested());
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+
+          await bloc.close();
+          completer.complete((<Message>[Message(
+            id: 999,
+            chatRoomId: 1,
+            senderId: 2,
+            content: 'late',
+            createdAt: DateTime.now(),
+          )], null, false));
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+        });
+
+        expect(errors, isEmpty,
+            reason: 'refresh await 이후 emit 가드가 없으면 emit-after-close 크래시');
+      });
+
+      test(
+          'P2: 파일 업로드 progress 콜백이 close() 이후 호출되어도 emit-after-close StateError가 없다',
+          () async {
+        // 실제 임시 파일 생성 (handleFileAttachment가 File.exists()를 검사).
+        final tmp = await File(
+          '${Directory.systemTemp.path}/cotalk_upload_${DateTime.now().microsecondsSinceEpoch}.txt',
+        ).create();
+        await tmp.writeAsString('hello');
+
+        final errors = await runCapturingErrors(() async {
+          // uploadFile을 느리게 만들어, 업로드 도중 close를 끼워넣은 뒤
+          // onProgress(0.5)/onProgress(1.0) 콜백이 closed bloc으로 향하게 한다.
+          final uploadCompleter = Completer<FileUploadResult>();
+          when(() => mockChatRepository.uploadFile(any()))
+              .thenAnswer((_) => uploadCompleter.future);
+          when(() => mockChatRepository.sendFileMessage(
+                roomId: any(named: 'roomId'),
+                fileUrl: any(named: 'fileUrl'),
+                fileName: any(named: 'fileName'),
+                fileSize: any(named: 'fileSize'),
+                contentType: any(named: 'contentType'),
+                thumbnailUrl: any(named: 'thumbnailUrl'),
+              )).thenAnswer((_) async => FakeEntities.textMessage);
+
+          final bloc = createBloc();
+          // roomId가 있어야 업로드가 진행된다.
+          bloc.add(const ChatRoomOpened(1));
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+
+          bloc.add(FileAttachmentRequested(tmp.path));
+          // onProgress(0.0) emit까지 진행, uploadFile await에 진입.
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+
+          await bloc.close();
+
+          // 업로드 완료 → onProgress(0.5), sendFileMessage, onProgress(1.0)이
+          // closed bloc에서 호출된다. 가드가 없으면 여기서 크래시.
+          uploadCompleter.complete(const FileUploadResult(
+            fileUrl: 'http://x/f.txt',
+            fileName: 'f.txt',
+            contentType: 'text/plain',
+            fileSize: 5,
+            isImage: false,
+          ));
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+        });
+
+        expect(
+          errors,
+          isEmpty,
+          reason: 'progress 콜백 emit에 isClosed 가드가 없으면 emit-after-close 크래시',
+        );
+        await tmp.delete();
+      });
+    });
   });
 }

--- a/test/blocs/chat_room_bloc_test.dart
+++ b/test/blocs/chat_room_bloc_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:bloc_test/bloc_test.dart';
+import 'package:co_talk_flutter/core/services/active_room_tracker.dart';
 import 'package:co_talk_flutter/core/network/websocket_service.dart';
 import 'package:co_talk_flutter/core/network/websocket/websocket_events.dart';
 import 'package:co_talk_flutter/domain/entities/chat_room.dart';
@@ -4150,6 +4151,67 @@ void main() {
           reason: 'progress 콜백 emit에 isClosed 가드가 없으면 emit-after-close 크래시',
         );
         await tmp.delete();
+      });
+    });
+
+    group('P3: activeRoomId 소유권 가드 (방 전환 race)', () {
+      test(
+          'A 닫힘 처리가 이미 B로 설정된 activeRoomId를 지우지 않는다 (소유권 가드)',
+          () async {
+        // 실제 ActiveRoomTracker + 상태를 보유하는 bridge 스텁 사용.
+        final realTracker = ActiveRoomTracker();
+        final statefulBridge = MockDesktopNotificationBridge();
+        int? bridgeRoomId;
+        when(() => statefulBridge.activeRoomId).thenAnswer((_) => bridgeRoomId);
+        when(() => statefulBridge.setActiveRoomId(any())).thenAnswer((inv) {
+          bridgeRoomId = inv.positionalArguments.first as int?;
+        });
+
+        when(() => mockChatRepository.getMessages(any(), size: any(named: 'size')))
+            .thenAnswer((_) async => (<Message>[], null, false));
+        when(() => mockChatRepository.markAsRead(any())).thenAnswer((_) async {});
+
+        ChatRoomBloc buildBloc() => ChatRoomBloc(
+              mockChatRepository,
+              mockWebSocketService,
+              mockAuthLocalDataSource,
+              statefulBridge,
+              realTracker,
+              mockFriendRepository,
+              mockSettingsRepository,
+            );
+
+        // 방 A 진입 → activeRoomId = A(1)
+        final blocA = buildBloc();
+        blocA.add(const ChatRoomOpened(1));
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        expect(realTracker.activeRoomId, 1);
+        expect(bridgeRoomId, 1);
+
+        // 방 B 진입 → activeRoomId = B(2) (B의 ChatRoomOpened가 먼저 실행)
+        final blocB = buildBloc();
+        blocB.add(const ChatRoomOpened(2));
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        expect(realTracker.activeRoomId, 2);
+        expect(bridgeRoomId, 2);
+
+        // 이제 A의 dispose/_onClosed가 뒤늦게 실행됨.
+        blocA.add(const ChatRoomClosed());
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+
+        // 소유권 가드: A는 자기 방(1)일 때만 지워야 하므로 B(2)는 유지되어야 한다.
+        expect(realTracker.activeRoomId, 2,
+            reason: 'A의 close가 B의 active 설정을 덮어쓰면 안 된다');
+        expect(bridgeRoomId, 2);
+
+        // B가 정상적으로 닫히면 자기 소유이므로 해제된다.
+        blocB.add(const ChatRoomClosed());
+        await Future<void>.delayed(const Duration(milliseconds: 30));
+        expect(realTracker.activeRoomId, isNull);
+        expect(bridgeRoomId, isNull);
+
+        await blocA.close();
+        await blocB.close();
       });
     });
   });


### PR DESCRIPTION
## 배경

점검에서 발견한 ChatRoomBloc 생명주기 결함 3건을 TDD로 수정합니다.

- **P1 — await 이후 무방비 emit**: 다수의 async 핸들러가 `await` 도중 사용자가 방을 빠르게 나가 bloc이 close되면, future 완료 후 `emit`이 호출되어 emit-after-close 크래시로 이어질 수 있습니다.
- **P2 — 파일 업로드 progress 콜백 emit**: 업로드 진행 중 이탈 시 `onProgress` 콜백이 closed bloc에 emit합니다.
- **P3 — 방 전환 시 activeRoomId race**: A→B 빠른 전환 시 B의 `ChatRoomOpened`가 `activeRoomId=B`를 설정한 뒤 A의 dispose/`_onClosed`가 뒤늦게 실행되며 무조건 `null`로 덮어써, 보고 있는 방 B의 FCM 알림 억제가 풀립니다.

## 변경

### P1/P2 — emit-after-close 가드 통일 (`7aa2dcc`)
- 각 `await` 직후 `emit` 앞에 `if (isClosed) return;` 가드 추가. 대상: `_onOpened`, `_onRefreshRequested`, `_onForegrounded`, `_onLoadMore`, `_onMessageDeleted`, `_onMessageUpdateRequested`, `_onLeaveRequested`, `_onReinviteUserRequested`, `_onMessageForwardRequested`.
- 파일 업로드 `onProgress` 콜백 emit에도 `isClosed` 가드.
- 기존 코드의 `.then`/타이머 콜백 `!isClosed` 패턴과 동일 스타일로 통일.

### P3 — activeRoomId 소유권 가드 (`bffe5fe`)
- `ChatRoomBloc._onClosed`: 현재 `activeRoomId`가 닫히는 방(`state.roomId`)과 같을 때만 해제(set/clear 소유 검증). `DesktopNotificationBridge`·`ActiveRoomTracker` 양쪽.
- `ChatRoomPage.dispose`: 동기 해제 경로도 `activeRoomId == widget.roomId`일 때만 `null` 처리.

## 회귀 테스트 (`test/blocs/chat_room_bloc_test.dart`)
- **P1/P2**: `await`/progress 도중 `bloc.close()` 후 future를 완료시키고, `runZonedGuarded`로 캡처한 uncaught error가 없음을 단언(3 케이스: `_onOpened`, `_onRefreshRequested`, 파일 업로드).
- **P3**: 실제 `ActiveRoomTracker`로 A active → B active 전환을 재현해, A의 `_onClosed`가 B(2)를 지우지 않고 B 자신이 닫힐 때만 해제됨을 검증. (가드 제거 시 `Actual: null`로 RED 확인 완료.)

## 검증 결과 / 한계

- `flutter analyze`: **0 issues**
- `flutter test` 전체: **+1748 ~2 (skip)**, 0 실패. baseline(main) +1744 대비 신규 테스트 **+4**, 회귀 0건.
- **솔직한 한계 보고**: 현재 의존 버전 `bloc 8.1.4`에서는 close에 의한 emit(`emit` 시 emitter가 `_isCanceled` 상태)이 **조용한 no-op**으로 처리되어, P1/P2의 await-경로 emit-after-close가 이 버전에서는 실제 크래시로 재현되지 않습니다. 따라서 추가한 `isClosed` 가드는 **방어적 강화 + bloc 공식 권장 패턴 준수**의 성격이며(향후 bloc 업그레이드/`_isCompleted` 경로 대비), 테스트는 "uncaught error 없음"을 단언하는 회귀 가드로 유지됩니다. 반면 **P3 race는 실제로 재현되어**(테스트가 가드 없이는 실패) 명확한 버그 수정입니다.
- P3 페이지 dispose 가드는 위젯 테스트에서 `ActiveRoomTracker`의 DI 미등록(테스트 환경)으로 직접 검증이 어려워, 동일 소유권 로직을 bloc 레벨 테스트로 커버했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)