### PR TITLE
fix(auth): 동시 401 시 refresh single-flight로 토큰 회전 중복 로그아웃 방지

### DIFF
--- a/lib/core/network/auth_interceptor.dart
+++ b/lib/core/network/auth_interceptor.dart
@@ -137,13 +137,22 @@ class AuthInterceptor extends QueuedInterceptor {
           // Use refresh Dio instance to retry (avoids circular dependency)
           final response = await _refreshDio.fetch(options);
           return handler.resolve(response);
-        } catch (e) {
-          // 재시도 자체가 실패하면 원본 에러를 전파한다.
+        } catch (e, stackTrace) {
+          // 재시도 자체가 실패하면 재시도 단계의 진짜 원인을 전파한다.
           // (refresh는 성공했으므로 강제 로그아웃하지 않는다)
           if (e is DioException) {
             return handler.next(e);
           }
-          return handler.next(err);
+          // 비-Dio 예외(직렬화·타입 오류 등)는 원본 401(err)로 가리지 않고
+          // 실제 원인(e)을 DioException으로 감싸 보존해 전파한다.
+          return handler.next(
+            DioException(
+              requestOptions: options,
+              error: e,
+              stackTrace: stackTrace,
+              type: DioExceptionType.unknown,
+            ),
+          );
         }
       }
 

--- a/lib/core/network/auth_interceptor.dart
+++ b/lib/core/network/auth_interceptor.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:injectable/injectable.dart';
 import '../constants/api_constants.dart';
 import '../../data/datasources/local/auth_local_datasource.dart';
@@ -17,6 +18,17 @@ class AuthInterceptor extends QueuedInterceptor {
 
   // Dispose flag to prevent operations after disposal
   bool _isDisposed = false;
+
+  // Single-flight refresh: 동시 401 발생 시 refresh를 1회만 수행하고
+  // 나머지 대기 요청들은 진행 중인 refresh의 결과(Future)를 공유한다.
+  // 서버가 refresh token rotation(1회용)을 사용하므로, 큐의 후속 요청이
+  // 이미 무효화된(revoked) refresh token으로 재갱신을 시도해 강제 로그아웃되는
+  // 결함을 방지한다.
+  Future<Map<String, String>?>? _inFlightRefresh;
+
+  /// 테스트 전용: refresh 요청을 가로채기 위해 _refreshDio를 노출한다.
+  @visibleForTesting
+  Dio get refreshDio => _refreshDio;
 
   AuthInterceptor(this._authLocalDataSource) {
     // 토큰 갱신 전용 클라이언트 생성 (인터셉터 없이)
@@ -103,37 +115,76 @@ class AuthInterceptor extends QueuedInterceptor {
     }
 
     if (err.response?.statusCode == 401 && !isAuthEndpoint) {
-      // Token expired, try to refresh
-      final refreshToken = await _authLocalDataSource.getRefreshToken();
-      if (refreshToken != null) {
-        try {
-          final newTokens = await _refreshToken(refreshToken);
-          if (newTokens != null) {
-            // Save new tokens
-            await _authLocalDataSource.saveTokens(
-              accessToken: newTokens['accessToken']!,
-              refreshToken: newTokens['refreshToken']!,
-            );
-
-            // Retry the original request with new token
-            final options = err.requestOptions;
-            options.headers['Authorization'] = 'Bearer ${newTokens['accessToken']}';
-
-            // Use refresh Dio instance to retry (avoids circular dependency)
-            final response = await _refreshDio.fetch(options);
-            return handler.resolve(response);
-          }
-        } catch (e) {
-          // Refresh failed, clear tokens and logout
-          await _forceLogout();
-        }
-      } else {
-        // Refresh token이 없는 경우도 로그아웃 처리
-        await _forceLogout();
+      // 동시 401 처리: refresh는 single-flight로 1회만 수행한다.
+      // 이미 진행 중인 refresh가 있으면 그 결과(Future)를 공유하고,
+      // 없으면 새 refresh를 시작한다. 큐의 후속 요청이 옛(이미 회전된)
+      // refresh token으로 다시 갱신을 시도하지 않도록 보장한다.
+      Map<String, String>? newTokens;
+      try {
+        newTokens = await _ensureRefreshed();
+      } catch (_) {
+        newTokens = null;
       }
+
+      if (newTokens != null) {
+        // Retry the original request with the new access token.
+        // 큐에 대기하던 요청도 항상 최신 access token으로 헤더를 교체한다.
+        final options = err.requestOptions;
+        options.headers['Authorization'] =
+            'Bearer ${newTokens['accessToken']}';
+
+        try {
+          // Use refresh Dio instance to retry (avoids circular dependency)
+          final response = await _refreshDio.fetch(options);
+          return handler.resolve(response);
+        } catch (e) {
+          // 재시도 자체가 실패하면 원본 에러를 전파한다.
+          // (refresh는 성공했으므로 강제 로그아웃하지 않는다)
+          if (e is DioException) {
+            return handler.next(e);
+          }
+          return handler.next(err);
+        }
+      }
+
+      // 여기 도달 = refresh가 진짜로 실패(만료/무효/토큰 없음)한 경우에만
+      // 강제 로그아웃한다. 한 번의 rotation으로 인한 후속 401은
+      // single-flight 공유 결과로 흡수되므로 여기까지 오지 않는다.
+      await _forceLogout();
     }
 
     handler.next(err);
+  }
+
+  /// Single-flight refresh.
+  ///
+  /// 진행 중인 refresh가 있으면 그 Future를 그대로 반환하고,
+  /// 없으면 새 refresh를 1회 시작한다. 성공 시 새 토큰을 저장한 뒤
+  /// 토큰 맵을 반환하고, 실패(만료/무효/토큰 없음) 시 null을 반환한다.
+  Future<Map<String, String>?> _ensureRefreshed() {
+    return _inFlightRefresh ??= _performRefresh().whenComplete(() {
+      _inFlightRefresh = null;
+    });
+  }
+
+  Future<Map<String, String>?> _performRefresh() async {
+    final refreshToken = await _authLocalDataSource.getRefreshToken();
+    if (refreshToken == null) {
+      return null;
+    }
+
+    final newTokens = await _refreshToken(refreshToken);
+    if (newTokens == null) {
+      return null;
+    }
+
+    // Save new tokens (rotation: 옛 refresh token은 서버에서 이미 무효화됨)
+    await _authLocalDataSource.saveTokens(
+      accessToken: newTokens['accessToken']!,
+      refreshToken: newTokens['refreshToken']!,
+    );
+
+    return newTokens;
   }
 
   /// 강제 로그아웃 처리

--- a/test/core/auth_interceptor_test.dart
+++ b/test/core/auth_interceptor_test.dart
@@ -85,6 +85,42 @@ class RotatingRefreshAdapter implements HttpClientAdapter {
   void close({bool force = false}) {}
 }
 
+/// 재시도 단계에서 던져지는 비-Dio 예외(직렬화·타입 오류 등을 흉내).
+class _RetryBoom implements Exception {
+  @override
+  String toString() => '_RetryBoom: non-Dio retry failure';
+}
+
+/// `/auth/refresh`는 정상적으로 새 토큰을 발급하지만, 보호된 리소스 재시도
+/// 요청에 대해서는 비-Dio 예외(`_RetryBoom`)를 던지는 어댑터.
+class _RetryThrowsNonDioAdapter implements HttpClientAdapter {
+  _RetryThrowsNonDioAdapter({required this.validRefreshToken});
+
+  final String validRefreshToken;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    if (options.path.contains('/auth/refresh')) {
+      return ResponseBody.fromString(
+        jsonEncode({'accessToken': 'access_1', 'refreshToken': 'refresh_1'}),
+        200,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      );
+    }
+    // 재시도 요청 → 비-Dio 예외 발생
+    throw _RetryBoom();
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
 void main() {
   late MockAuthLocalDataSource mockLocalDataSource;
   late AuthInterceptor interceptor;
@@ -463,6 +499,45 @@ void main() {
         verifyNever(() => mockLocalDataSource.clearTokens());
         verifyNever(() => handlerA.next(any()));
         verifyNever(() => handlerB.next(any()));
+      });
+
+      test(
+          'non-Dio retry failure propagates real cause (not original 401)',
+          () async {
+        // refresh는 성공시키되, 보호된 리소스 재시도 시 비-Dio 예외(타입 오류 등)를
+        // 던지는 어댑터로 교체한다.
+        interceptor.refreshDio.httpClientAdapter =
+            _RetryThrowsNonDioAdapter(validRefreshToken: 'refresh_0');
+
+        final error = DioException(
+          requestOptions: RequestOptions(
+            path: '/users/me',
+            headers: {'Authorization': 'Bearer access_0'},
+          ),
+          response: Response(
+            requestOptions: RequestOptions(path: '/users/me'),
+            statusCode: 401,
+          ),
+        );
+        final handler = MockErrorInterceptorHandler();
+        DioException? propagated;
+        when(() => handler.next(any())).thenAnswer((inv) {
+          propagated = inv.positionalArguments[0] as DioException;
+        });
+        when(() => handler.resolve(any())).thenReturn(null);
+
+        interceptor.onError(error, handler);
+
+        await Future.delayed(const Duration(milliseconds: 300));
+
+        // 재시도 단계의 진짜 원인이 보존되어 전파되어야 한다 (원본 401이 아님).
+        expect(propagated, isNotNull);
+        expect(propagated, isNot(same(error)),
+            reason: 'must not mask retry failure with original 401');
+        expect(propagated!.error, isA<_RetryBoom>(),
+            reason: 'real non-Dio cause must be preserved');
+        // refresh는 성공했으므로 강제 로그아웃하지 않는다.
+        verifyNever(() => mockLocalDataSource.clearTokens());
       });
 
       test('genuine refresh failure (revoked/expired) still forces logout',

--- a/test/core/auth_interceptor_test.dart
+++ b/test/core/auth_interceptor_test.dart
@@ -1,3 +1,6 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:dio/dio.dart';
@@ -13,6 +16,74 @@ class MockErrorInterceptorHandler extends Mock
     implements ErrorInterceptorHandler {}
 
 class MockResponse extends Mock implements Response {}
+
+/// Refresh token rotation(1회용)을 흉내내는 가짜 서버 어댑터.
+///
+/// - `/auth/refresh` 요청의 본문에 들어있는 refreshToken이 현재 유효한
+///   토큰과 일치하면 새 토큰 쌍을 발급하고, 옛 토큰을 즉시 무효화한다.
+/// - 이미 무효화된(rotated) refresh token으로 다시 갱신을 시도하면
+///   서버처럼 401을 반환한다.
+/// - 그 외(보호된 리소스 재시도) 요청은 항상 200을 반환한다.
+class RotatingRefreshAdapter implements HttpClientAdapter {
+  RotatingRefreshAdapter({required String initialRefreshToken})
+      : _validRefreshToken = initialRefreshToken;
+
+  String? _validRefreshToken;
+  int refreshCallCount = 0;
+  final List<String> issuedAccessTokens = [];
+  int _accessCounter = 0;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    if (options.path.contains('/auth/refresh')) {
+      refreshCallCount++;
+      final body = options.data as Map?;
+      final presented = body?['refreshToken'] as String?;
+
+      // rotation: 이미 무효화된(또는 옛) refresh token이면 401
+      if (presented == null || presented != _validRefreshToken) {
+        return ResponseBody.fromString(
+          jsonEncode({'code': 'INVALID_REFRESH_TOKEN'}),
+          401,
+          headers: {
+            Headers.contentTypeHeader: [Headers.jsonContentType],
+          },
+        );
+      }
+
+      // 갱신 성공 → 옛 refresh token 무효화, 새 토큰 쌍 발급
+      _accessCounter++;
+      final newAccess = 'access_$_accessCounter';
+      final newRefresh = 'refresh_$_accessCounter';
+      issuedAccessTokens.add(newAccess);
+      _validRefreshToken = newRefresh;
+
+      return ResponseBody.fromString(
+        jsonEncode({'accessToken': newAccess, 'refreshToken': newRefresh}),
+        200,
+        headers: {
+          Headers.contentTypeHeader: [Headers.jsonContentType],
+        },
+      );
+    }
+
+    // 보호된 리소스 재시도는 성공으로 처리
+    return ResponseBody.fromString(
+      jsonEncode({'ok': true}),
+      200,
+      headers: {
+        Headers.contentTypeHeader: [Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
 
 void main() {
   late MockAuthLocalDataSource mockLocalDataSource;
@@ -290,6 +361,136 @@ void main() {
         await Future.delayed(const Duration(milliseconds: 100));
 
         verify(() => handler.next(error)).called(1);
+      });
+    });
+
+    group('concurrent 401 with refresh token rotation', () {
+      late RotatingRefreshAdapter adapter;
+
+      // 인메모리 토큰 저장소: 실제 rotation을 반영하기 위해
+      // saveTokens / getRefreshToken / getAccessToken을 stateful하게 흉내낸다.
+      String? storedAccess = 'access_0';
+      String? storedRefresh = 'refresh_0';
+
+      setUp(() {
+        storedAccess = 'access_0';
+        storedRefresh = 'refresh_0';
+
+        adapter = RotatingRefreshAdapter(initialRefreshToken: 'refresh_0');
+        interceptor.refreshDio.httpClientAdapter = adapter;
+
+        when(() => mockLocalDataSource.getAccessToken())
+            .thenAnswer((_) async => storedAccess);
+        when(() => mockLocalDataSource.getRefreshToken())
+            .thenAnswer((_) async => storedRefresh);
+        when(() => mockLocalDataSource.saveTokens(
+              accessToken: any(named: 'accessToken'),
+              refreshToken: any(named: 'refreshToken'),
+            )).thenAnswer((invocation) async {
+          // 저장 지연을 흉내내 race 가능성을 노출시킨다.
+          await Future<void>.delayed(const Duration(milliseconds: 10));
+          storedAccess =
+              invocation.namedArguments[#accessToken] as String?;
+          storedRefresh =
+              invocation.namedArguments[#refreshToken] as String?;
+        });
+        when(() => mockLocalDataSource.clearTokens()).thenAnswer((_) async {
+          storedAccess = null;
+          storedRefresh = null;
+        });
+      });
+
+      test(
+          'two concurrent 401s trigger refresh ONCE, both retry with new token, no logout',
+          () async {
+        final errorA = DioException(
+          requestOptions: RequestOptions(
+            path: '/users/me',
+            headers: {'Authorization': 'Bearer access_0'},
+          ),
+          response: Response(
+            requestOptions: RequestOptions(path: '/users/me'),
+            statusCode: 401,
+          ),
+        );
+        final errorB = DioException(
+          requestOptions: RequestOptions(
+            path: '/chat/rooms',
+            headers: {'Authorization': 'Bearer access_0'},
+          ),
+          response: Response(
+            requestOptions: RequestOptions(path: '/chat/rooms'),
+            statusCode: 401,
+          ),
+        );
+
+        final handlerA = MockErrorInterceptorHandler();
+        final handlerB = MockErrorInterceptorHandler();
+        Response? resolvedA;
+        Response? resolvedB;
+        when(() => handlerA.resolve(any())).thenAnswer((inv) {
+          resolvedA = inv.positionalArguments[0] as Response;
+        });
+        when(() => handlerB.resolve(any())).thenAnswer((inv) {
+          resolvedB = inv.positionalArguments[0] as Response;
+        });
+        when(() => handlerA.next(any())).thenReturn(null);
+        when(() => handlerB.next(any())).thenReturn(null);
+
+        // 동시에 두 개의 401을 발생시킨다.
+        interceptor.onError(errorA, handlerA);
+        interceptor.onError(errorB, handlerB);
+
+        await Future.delayed(const Duration(milliseconds: 500));
+
+        // refresh는 정확히 1회만 호출되어야 한다 (single-flight).
+        expect(adapter.refreshCallCount, 1,
+            reason: 'refresh must be performed exactly once (single-flight)');
+
+        // 두 요청 모두 성공적으로 resolve 되어야 한다.
+        expect(resolvedA, isNotNull,
+            reason: 'request A should be retried and resolved');
+        expect(resolvedB, isNotNull,
+            reason: 'request B should be retried and resolved');
+
+        // 두 요청 모두 새 access token으로 재시도되어야 한다.
+        expect(errorA.requestOptions.headers['Authorization'],
+            'Bearer access_1');
+        expect(errorB.requestOptions.headers['Authorization'],
+            'Bearer access_1');
+
+        // 강제 로그아웃이 발생하면 안 된다.
+        verifyNever(() => mockLocalDataSource.clearTokens());
+        verifyNever(() => handlerA.next(any()));
+        verifyNever(() => handlerB.next(any()));
+      });
+
+      test('genuine refresh failure (revoked/expired) still forces logout',
+          () async {
+        // 저장된 refresh token이 서버가 모르는(이미 무효화된) 값이도록 설정
+        storedRefresh = 'already_revoked';
+
+        final error = DioException(
+          requestOptions: RequestOptions(
+            path: '/users/me',
+            headers: {'Authorization': 'Bearer access_0'},
+          ),
+          response: Response(
+            requestOptions: RequestOptions(path: '/users/me'),
+            statusCode: 401,
+          ),
+        );
+        final handler = MockErrorInterceptorHandler();
+        when(() => handler.next(any())).thenReturn(null);
+        when(() => handler.resolve(any())).thenReturn(null);
+
+        interceptor.onError(error, handler);
+
+        await Future.delayed(const Duration(milliseconds: 300));
+
+        // 진짜 만료/무효 → 강제 로그아웃 유지
+        verify(() => mockLocalDataSource.clearTokens()).called(1);
+        verify(() => handler.next(any())).called(1);
       });
     });
 


### PR DESCRIPTION
## 배경

서버는 refresh token **rotation(1회용)** 정책을 사용한다. 갱신 시 옛 refresh token을 즉시 `revoked` 처리하고 새 refresh를 발급하므로, 같은 refresh token으로 2번째 갱신을 시도하면 401(`InvalidRefreshTokenException`)이 발생한다.

기존 `AuthInterceptor`는 `QueuedInterceptor`로 `onError`를 직렬화하긴 했지만, **각 401 요청이 독립적으로 refresh를 호출**했다. 이로 인해 동시 401 상황에서:

1. 요청 A,B가 동시에 401 → 큐잉
2. A가 RT0로 refresh 성공 → 서버가 RT0 무효화, RT1 발급
3. 큐의 B가 옛 RT0로 **다시 refresh 시도** → 서버 401(이미 revoked) → **강제 로그아웃**

(비동기 토큰 저장 지연 시 B가 stale RT0를 읽어 위 경로로 빠진다)

## 변경

- **single-flight refresh** (`_ensureRefreshed`): 진행 중인 refresh가 있으면 그 `Future`를 공유하고, 없을 때만 새 refresh를 1회 시작. 완료 시 in-flight 슬롯을 비운다.
- 대기/재시도 요청은 **항상 갱신된 새 access token으로 Authorization 헤더를 교체**한 뒤 재시도. 옛 access 재시도 / 옛 refresh 재-refresh 금지.
- refresh가 **진짜 실패**(만료/무효/토큰 없음)한 경우에만 강제 로그아웃. 한 번의 rotation으로 인한 후속 401은 공유 결과로 흡수되어 로그아웃을 유발하지 않는다.
- 재시도 자체가 실패하면 로그아웃하지 않고 원본 에러를 전파.

## 테스트 (TDD)

- `RotatingRefreshAdapter`: 1회용 refresh 서버를 흉내내는 가짜 `HttpClientAdapter`(옛 토큰 재사용 시 401).
- **동시 2개 401 → refresh 정확히 1회 호출, 둘 다 새 access token(`access_1`)으로 재시도 성공, 강제 로그아웃 없음**. (수정 전에는 refreshCallCount=2로 실패)
- 진짜 만료/무효 refresh token → 강제 로그아웃 유지.

## 검증

- `flutter analyze`: **No issues found**
- `flutter test`: **1760 passed, 2 skipped, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)