### PR TITLE
feat(file): 파일 메시지를 불투명 object-id로 전송

### DIFF
--- a/lib/core/network/websocket/websocket_message_sender.dart
+++ b/lib/core/network/websocket/websocket_message_sender.dart
@@ -51,6 +51,8 @@ class WebSocketMessageSender {
     required int fileSize,
     required String contentType,
     String? thumbnailUrl,
+    String? objectId,
+    String? thumbnailObjectId,
   }) {
     if (stompClient == null || !stompClient.connected) {
       if (kDebugMode) {
@@ -63,6 +65,9 @@ class WebSocketMessageSender {
       destination: WebSocketConfig.sendFileMessageDestination,
       body: jsonEncode({
         'roomId': roomId,
+        // 신규 방식: object-id (서버가 존재 시 우선 사용). 하위호환을 위해 fileUrl도 함께 전송.
+        if (objectId != null) 'objectId': objectId,
+        if (thumbnailObjectId != null) 'thumbnailObjectId': thumbnailObjectId,
         'fileUrl': fileUrl,
         'fileName': fileName,
         'fileSize': fileSize,

--- a/lib/core/network/websocket/websocket_message_sender.dart
+++ b/lib/core/network/websocket/websocket_message_sender.dart
@@ -43,6 +43,10 @@ class WebSocketMessageSender {
   /// Sends a file message.
   ///
   /// Returns false if not connected.
+  ///
+  /// NOTE: 실제 파일 메시지 전송은 REST(`SendFileMessageRequest`) 경로를 사용한다.
+  /// [objectId]/[thumbnailObjectId]는 현재 이 WS 경로에서 미사용이며(호출부 전부 null),
+  /// 향후 WS 파일 전송 시 REST 경로와의 일관성을 위해 옵셔널로 미리 배선해 둔 것이다.
   bool sendFileMessage({
     required StompClient? stompClient,
     required int roomId,

--- a/lib/core/network/websocket_service.dart
+++ b/lib/core/network/websocket_service.dart
@@ -279,6 +279,8 @@ class WebSocketService {
     required int fileSize,
     required String contentType,
     String? thumbnailUrl,
+    String? objectId,
+    String? thumbnailObjectId,
   }) {
     return _messageSender.sendFileMessage(
       stompClient: _connectionManager.stompClient,
@@ -288,6 +290,8 @@ class WebSocketService {
       fileSize: fileSize,
       contentType: contentType,
       thumbnailUrl: thumbnailUrl,
+      objectId: objectId,
+      thumbnailObjectId: thumbnailObjectId,
     );
   }
 

--- a/lib/data/datasources/remote/chat_remote_datasource.dart
+++ b/lib/data/datasources/remote/chat_remote_datasource.dart
@@ -667,6 +667,12 @@ class ChatRemoteDataSourceImpl extends BaseRemoteDataSource
 
 /// 파일 업로드 응답 모델
 class FileUploadResponse {
+  /// 업로드된 객체의 불투명 식별자(저장 객체 키).
+  ///
+  /// 서버(co-talk feat/file-message-opaque-id 이후)가 내려주는 값으로, 파일 메시지 전송 시
+  /// URL 대신 이 값을 보내면 서버가 소유·존재를 검증하고 URL/메타를 재구성한다.
+  /// 구버전 서버에서는 null일 수 있으므로 옵셔널로 둔다.
+  final String? objectId;
   final String fileUrl;
   final String fileName;
   final String contentType;
@@ -674,6 +680,7 @@ class FileUploadResponse {
   final bool isImage;
 
   const FileUploadResponse({
+    this.objectId,
     required this.fileUrl,
     required this.fileName,
     required this.contentType,
@@ -683,6 +690,7 @@ class FileUploadResponse {
 
   factory FileUploadResponse.fromJson(Map<String, dynamic> json) {
     return FileUploadResponse(
+      objectId: json['objectId'] as String?,
       fileUrl: json['fileUrl'] as String,
       fileName: json['fileName'] as String,
       contentType: json['contentType'] as String,
@@ -693,8 +701,19 @@ class FileUploadResponse {
 }
 
 /// 파일 메시지 전송 요청 모델
+///
+/// 신규 방식(권장)은 업로드가 발급한 불투명 식별자 [objectId]를 보낸다. 서버가 소유·존재를
+/// 검증하고 URL/contentType/size를 재구성하므로 클라이언트가 임의 URL을 주입할 여지가 없다.
+/// 하위호환을 위해 [fileUrl]도 함께 보낸다(구버전 서버는 fileUrl을, 신버전 서버는 objectId를 사용).
 class SendFileMessageRequest {
   final int chatRoomId;
+
+  /// 업로드가 발급한 불투명 식별자(저장 객체 키). 신규 방식에서 사용.
+  final String? objectId;
+
+  /// 썸네일 불투명 식별자. 신규 방식에서 사용.
+  final String? thumbnailObjectId;
+
   final String fileUrl;
   final String fileName;
   final int fileSize;
@@ -703,6 +722,8 @@ class SendFileMessageRequest {
 
   const SendFileMessageRequest({
     required this.chatRoomId,
+    this.objectId,
+    this.thumbnailObjectId,
     required this.fileUrl,
     required this.fileName,
     required this.fileSize,
@@ -713,6 +734,10 @@ class SendFileMessageRequest {
   Map<String, dynamic> toJson() {
     return {
       'chatRoomId': chatRoomId,
+      // 신규 방식: object-id (서버가 존재 시 우선 사용)
+      if (objectId != null) 'objectId': objectId,
+      if (thumbnailObjectId != null) 'thumbnailObjectId': thumbnailObjectId,
+      // 하위호환: 구버전 서버를 위해 fileUrl도 항상 포함
       'fileUrl': fileUrl,
       'fileName': fileName,
       'fileSize': fileSize,

--- a/lib/data/repositories/chat_repository_impl.dart
+++ b/lib/data/repositories/chat_repository_impl.dart
@@ -200,6 +200,7 @@ class ChatRepositoryImpl implements ChatRepository {
   Future<FileUploadResult> uploadFile(File file) async {
     final response = await _remoteDataSource.uploadFile(file);
     return FileUploadResult(
+      objectId: response.objectId,
       fileUrl: response.fileUrl,
       fileName: response.fileName,
       contentType: response.contentType,
@@ -216,10 +217,14 @@ class ChatRepositoryImpl implements ChatRepository {
     required int fileSize,
     required String contentType,
     String? thumbnailUrl,
+    String? objectId,
+    String? thumbnailObjectId,
   }) async {
     final messageModel = await _remoteDataSource.sendFileMessage(
       SendFileMessageRequest(
         chatRoomId: roomId,
+        objectId: objectId,
+        thumbnailObjectId: thumbnailObjectId,
         fileUrl: fileUrl,
         fileName: fileName,
         fileSize: fileSize,

--- a/lib/domain/repositories/chat_repository.dart
+++ b/lib/domain/repositories/chat_repository.dart
@@ -5,6 +5,11 @@ import '../entities/message.dart';
 
 /// 파일 업로드 결과
 class FileUploadResult {
+  /// 업로드된 객체의 불투명 식별자(저장 객체 키).
+  ///
+  /// 서버가 내려주면 파일 메시지 전송 시 URL 대신 이 값을 보낸다(서버가 메타 재구성).
+  /// 구버전 서버에서는 null일 수 있다.
+  final String? objectId;
   final String fileUrl;
   final String fileName;
   final String contentType;
@@ -12,6 +17,7 @@ class FileUploadResult {
   final bool isImage;
 
   const FileUploadResult({
+    this.objectId,
     required this.fileUrl,
     required this.fileName,
     required this.contentType,
@@ -47,6 +53,9 @@ abstract class ChatRepository {
 
   /// 파일/이미지 메시지를 전송합니다.
   /// senderId는 서버에서 JWT 토큰으로부터 추출합니다.
+  ///
+  /// [objectId]가 주어지면 서버가 그 불투명 식별자로 URL/메타를 재구성한다(권장).
+  /// [fileUrl]은 하위호환(구버전 서버)을 위해 함께 전송된다.
   Future<Message> sendFileMessage({
     required int roomId,
     required String fileUrl,
@@ -54,6 +63,8 @@ abstract class ChatRepository {
     required int fileSize,
     required String contentType,
     String? thumbnailUrl,
+    String? objectId,
+    String? thumbnailObjectId,
   });
 
   // Local-first methods

--- a/lib/presentation/blocs/chat/managers/message_handler.dart
+++ b/lib/presentation/blocs/chat/managers/message_handler.dart
@@ -162,8 +162,14 @@ class MessageHandler {
 
       onProgress(0.5);
 
+      // 신규 방식 우선: 업로드가 발급한 불투명 식별자(objectId)를 보낸다. 서버(co-talk
+      // feat/file-message-opaque-id 이후)가 이 값으로 URL/메타를 재구성한다. fileUrl은
+      // 하위호환(구버전 서버)을 위해 함께 전송된다. objectId가 없으면(구버전 서버 응답)
+      // 기존 fileUrl 경로로 동작한다.
       await _chatRepository.sendFileMessage(
         roomId: roomId,
+        objectId: uploadResult.objectId,
+        thumbnailObjectId: uploadResult.isImage ? uploadResult.objectId : null,
         fileUrl: uploadResult.fileUrl,
         fileName: uploadResult.fileName,
         fileSize: uploadResult.fileSize,

--- a/lib/presentation/blocs/chat/managers/message_handler.dart
+++ b/lib/presentation/blocs/chat/managers/message_handler.dart
@@ -166,6 +166,10 @@ class MessageHandler {
       // feat/file-message-opaque-id 이후)가 이 값으로 URL/메타를 재구성한다. fileUrl은
       // 하위호환(구버전 서버)을 위해 함께 전송된다. objectId가 없으면(구버전 서버 응답)
       // 기존 fileUrl 경로로 동작한다.
+      // 업로드 응답(FileUploadResult)에는 썸네일 전용 식별자가 없다(objectId 단일). 따라서
+      // 이미지일 때 썸네일 식별자도 원본 objectId를 그대로 보낸다 — 기존 thumbnailUrl이
+      // 이미지일 때 fileUrl을 재사용하던 동작과 동일한 의미다. 서버(co-talk #170)가 별도
+      // 썸네일 객체 키를 발급하게 되면 그 값으로 교체한다.
       await _chatRepository.sendFileMessage(
         roomId: roomId,
         objectId: uploadResult.objectId,

--- a/test/blocs/chat_room_bloc_test.dart
+++ b/test/blocs/chat_room_bloc_test.dart
@@ -3085,6 +3085,100 @@ void main() {
           verifyNever(() => mockChatRepository.uploadFile(any()));
         },
       );
+
+      // 회귀 가드: 업로드 결과의 objectId가 전송 요청으로 매핑되고,
+      // 이미지 분기에서 thumbnailObjectId가 원본 objectId로 채워지는지 검증.
+      blocTest<ChatRoomBloc, ChatRoomState>(
+        'maps upload objectId to sendFileMessage and fills thumbnailObjectId for image',
+        build: () {
+          when(() => mockChatRepository.uploadFile(any())).thenAnswer(
+            (_) async => const FileUploadResult(
+              objectId: 'obj-123',
+              fileUrl: 'https://example.com/file.jpg',
+              fileName: 'file.jpg',
+              contentType: 'image/jpeg',
+              fileSize: 1024,
+              isImage: true,
+            ),
+          );
+          when(() => mockChatRepository.sendFileMessage(
+                roomId: any(named: 'roomId'),
+                fileUrl: any(named: 'fileUrl'),
+                fileName: any(named: 'fileName'),
+                fileSize: any(named: 'fileSize'),
+                contentType: any(named: 'contentType'),
+                thumbnailUrl: any(named: 'thumbnailUrl'),
+                objectId: any(named: 'objectId'),
+                thumbnailObjectId: any(named: 'thumbnailObjectId'),
+              )).thenAnswer((_) async => FakeEntities.imageMessage);
+          return createBloc();
+        },
+        seed: () => const ChatRoomState(
+          status: ChatRoomStatus.success,
+          roomId: 1,
+        ),
+        act: (bloc) => bloc.add(FileAttachmentRequested(tempFilePath)),
+        wait: const Duration(milliseconds: 500),
+        verify: (_) {
+          verify(() => mockChatRepository.sendFileMessage(
+                roomId: 1,
+                fileUrl: 'https://example.com/file.jpg',
+                fileName: 'file.jpg',
+                fileSize: 1024,
+                contentType: 'image/jpeg',
+                thumbnailUrl: 'https://example.com/file.jpg',
+                objectId: 'obj-123',
+                // 이미지이므로 썸네일 식별자가 원본 objectId로 채워진다.
+                thumbnailObjectId: 'obj-123',
+              )).called(1);
+        },
+      );
+
+      // 회귀 가드: 비이미지 파일은 thumbnailObjectId/thumbnailUrl이 null로 전송된다.
+      blocTest<ChatRoomBloc, ChatRoomState>(
+        'sends null thumbnailObjectId for non-image file',
+        build: () {
+          when(() => mockChatRepository.uploadFile(any())).thenAnswer(
+            (_) async => const FileUploadResult(
+              objectId: 'obj-456',
+              fileUrl: 'https://example.com/doc.pdf',
+              fileName: 'doc.pdf',
+              contentType: 'application/pdf',
+              fileSize: 2048,
+              isImage: false,
+            ),
+          );
+          when(() => mockChatRepository.sendFileMessage(
+                roomId: any(named: 'roomId'),
+                fileUrl: any(named: 'fileUrl'),
+                fileName: any(named: 'fileName'),
+                fileSize: any(named: 'fileSize'),
+                contentType: any(named: 'contentType'),
+                thumbnailUrl: any(named: 'thumbnailUrl'),
+                objectId: any(named: 'objectId'),
+                thumbnailObjectId: any(named: 'thumbnailObjectId'),
+              )).thenAnswer((_) async => FakeEntities.imageMessage);
+          return createBloc();
+        },
+        seed: () => const ChatRoomState(
+          status: ChatRoomStatus.success,
+          roomId: 1,
+        ),
+        act: (bloc) => bloc.add(FileAttachmentRequested(tempFilePath)),
+        wait: const Duration(milliseconds: 500),
+        verify: (_) {
+          verify(() => mockChatRepository.sendFileMessage(
+                roomId: 1,
+                fileUrl: 'https://example.com/doc.pdf',
+                fileName: 'doc.pdf',
+                fileSize: 2048,
+                contentType: 'application/pdf',
+                thumbnailUrl: null,
+                objectId: 'obj-456',
+                thumbnailObjectId: null,
+              )).called(1);
+        },
+      );
     });
 
     group('MessageRetryRequested', () {

--- a/test/data/datasources/remote/chat_file_message_objectid_test.dart
+++ b/test/data/datasources/remote/chat_file_message_objectid_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:co_talk_flutter/data/datasources/remote/chat_remote_datasource.dart';
+
+void main() {
+  group('FileUploadResponse.fromJson - objectId', () {
+    test('objectId가 응답에 있으면 파싱한다', () {
+      final json = {
+        'objectId': 'uploads/42/abc.png',
+        'fileUrl': 'http://localhost:9000/cotalk/uploads/42/abc.png',
+        'fileName': 'abc.png',
+        'contentType': 'image/png',
+        'fileSize': 1234,
+        'isImage': true,
+      };
+
+      final response = FileUploadResponse.fromJson(json);
+
+      expect(response.objectId, 'uploads/42/abc.png');
+      expect(response.fileUrl, 'http://localhost:9000/cotalk/uploads/42/abc.png');
+    });
+
+    test('objectId가 없으면(구버전 서버) null로 둔다 (하위호환)', () {
+      final json = {
+        'fileUrl': 'http://localhost:9000/cotalk/uploads/42/abc.png',
+        'fileName': 'abc.png',
+        'contentType': 'image/png',
+        'fileSize': 1234,
+        'isImage': true,
+      };
+
+      final response = FileUploadResponse.fromJson(json);
+
+      expect(response.objectId, isNull);
+      expect(response.fileUrl, isNotNull);
+    });
+  });
+
+  group('SendFileMessageRequest.toJson - object-id 우선 전송', () {
+    test('objectId가 있으면 objectId와 fileUrl을 함께 전송한다(하위호환)', () {
+      const request = SendFileMessageRequest(
+        chatRoomId: 1,
+        objectId: 'uploads/42/abc.png',
+        thumbnailObjectId: 'uploads/42/thumb.png',
+        fileUrl: 'http://localhost:9000/cotalk/uploads/42/abc.png',
+        fileName: 'abc.png',
+        fileSize: 1234,
+        contentType: 'image/png',
+        thumbnailUrl: 'http://localhost:9000/cotalk/uploads/42/thumb.png',
+      );
+
+      final json = request.toJson();
+
+      // 신규: object-id 포함
+      expect(json['objectId'], 'uploads/42/abc.png');
+      expect(json['thumbnailObjectId'], 'uploads/42/thumb.png');
+      // 하위호환: fileUrl도 항상 포함
+      expect(json['fileUrl'], 'http://localhost:9000/cotalk/uploads/42/abc.png');
+      expect(json['contentType'], 'image/png');
+    });
+
+    test('objectId가 없으면(구버전 서버 응답) objectId 키를 보내지 않는다', () {
+      const request = SendFileMessageRequest(
+        chatRoomId: 1,
+        fileUrl: 'http://localhost:9000/cotalk/uploads/42/abc.png',
+        fileName: 'abc.png',
+        fileSize: 1234,
+        contentType: 'image/png',
+      );
+
+      final json = request.toJson();
+
+      expect(json.containsKey('objectId'), isFalse);
+      expect(json.containsKey('thumbnailObjectId'), isFalse);
+      expect(json['fileUrl'], 'http://localhost:9000/cotalk/uploads/42/abc.png');
+    });
+  });
+}


### PR DESCRIPTION
## 배경 / 목적
파일 메시지 전송 시 클라이언트가 `fileUrl/contentType/fileSize`를 직접 보내던 것을, **업로드가 발급한 불투명 식별자(object-id)** 를 보내도록 전환한다. 서버가 그 id로 URL·메타를 재구성하므로 클라이언트가 임의 URL/타입을 주입할 여지가 사라진다(근본 해결).

## ⚠️ 선행 조건 (배포 순서)
**서버 PR이 먼저 머지/배포되어야 한다**: co-talk `feat/file-message-opaque-id` (with-co-talk/co-talk#170).
서버가 업로드 응답에 `objectId`를 내려주고, 파일 메시지 전송에서 `objectId`를 수용해야 이 클라이언트 변경이 의미를 가진다.

## 무엇을 했나
- **업로드 응답 파싱**: `FileUploadResponse`/`FileUploadResult`에 옵셔널 `objectId` 추가(구버전 서버 응답은 `null`).
- **파일 메시지 전송**: `message_handler`가 업로드 결과의 `objectId`(이미지면 `thumbnailObjectId`도)를 전달. REST `SendFileMessageRequest.toJson`이 `objectId`가 있으면 함께 직렬화.
- **WebSocket 전송 경로**도 `objectId` 옵셔널 지원(일관성).

## 하위호환 / 안전성
- `toJson`은 `objectId`가 있어도 **`fileUrl`을 항상 함께 전송**한다. 따라서:
  - 신버전 서버: `objectId`를 우선 사용(서버가 메타 재구성).
  - 구버전 서버: `objectId`를 무시하고 기존 `fileUrl`로 동작.
- 업로드 응답에 `objectId`가 없으면(서버 미배포) `objectId=null`이 되어 자동으로 기존 `fileUrl` 경로로 동작한다.
- 따라서 서버 배포 전/후 모두 깨지지 않는다(서버 우선, fileUrl 폴백).

## 검증
- `flutter pub get` OK
- `flutter analyze`: **No issues found**
- `flutter test`: **전체 통과(1765 passed, 2 skipped)**. object-id 직렬화 계약 테스트 추가(`test/data/datasources/remote/chat_file_message_objectid_test.dart`).