### PR TITLE
fix(media): 갤러리 load-more 중복·OOM 및 친구요청 더블탭·아바타 캐시 개선

### DIFF
--- a/lib/presentation/blocs/chat/media_gallery_bloc.dart
+++ b/lib/presentation/blocs/chat/media_gallery_bloc.dart
@@ -142,11 +142,17 @@ class MediaGalleryBloc extends Bloc<MediaGalleryEvent, MediaGalleryState> {
         page: nextPage,
       );
 
-      // Deduplicate by messageId so an overlapping page (or a duplicate
-      // fetch that slipped through) never renders the same item twice.
-      final existingIds = state.items.map((e) => e.messageId).toSet();
+      // Deduplicate by messageId so the same item never renders twice. This
+      // intentionally guards against BOTH sources of duplication:
+      //   1) inter-page overlap (an item already present in state.items), and
+      //   2) intra-page repeats (the same messageId appearing twice within
+      //      this single response).
+      // `seenIds` starts as a snapshot of existing ids and is mutated as we
+      // iterate, so the first occurrence of each new messageId is kept and any
+      // later repeat (from either source) is dropped.
+      final seenIds = state.items.map((e) => e.messageId).toSet();
       final newItems = response.items
-          .where((item) => existingIds.add(item.messageId))
+          .where((item) => seenIds.add(item.messageId))
           .toList();
 
       emit(state.copyWith(

--- a/lib/presentation/blocs/chat/media_gallery_bloc.dart
+++ b/lib/presentation/blocs/chat/media_gallery_bloc.dart
@@ -81,6 +81,12 @@ class MediaGalleryState extends Equatable {
 class MediaGalleryBloc extends Bloc<MediaGalleryEvent, MediaGalleryState> {
   final ChatRemoteDataSource _chatRemoteDataSource;
 
+  /// Guards against concurrent load-more fetches. The `status == loading`
+  /// guard is insufficient because load-more does not flip status to loading,
+  /// so rapid scrolling could fire two LoadMore events that fetch the same
+  /// page and append duplicates. This in-flight flag drops the second event.
+  bool _isLoadingMore = false;
+
   MediaGalleryBloc(this._chatRemoteDataSource) : super(const MediaGalleryState()) {
     on<MediaGalleryLoadRequested>(_onLoadRequested);
     on<MediaGalleryLoadMoreRequested>(_onLoadMoreRequested);
@@ -122,9 +128,11 @@ class MediaGalleryBloc extends Bloc<MediaGalleryEvent, MediaGalleryState> {
     MediaGalleryLoadMoreRequested event,
     Emitter<MediaGalleryState> emit,
   ) async {
+    if (_isLoadingMore) return;
     if (!state.hasMore || state.status == MediaGalleryStatus.loading) return;
     if (state.roomId == null || state.currentType == null) return;
 
+    _isLoadingMore = true;
     final nextPage = state.currentPage + 1;
 
     try {
@@ -134,14 +142,23 @@ class MediaGalleryBloc extends Bloc<MediaGalleryEvent, MediaGalleryState> {
         page: nextPage,
       );
 
+      // Deduplicate by messageId so an overlapping page (or a duplicate
+      // fetch that slipped through) never renders the same item twice.
+      final existingIds = state.items.map((e) => e.messageId).toSet();
+      final newItems = response.items
+          .where((item) => existingIds.add(item.messageId))
+          .toList();
+
       emit(state.copyWith(
-        items: [...state.items, ...response.items],
+        items: [...state.items, ...newItems],
         nextCursor: response.nextCursor,
         hasMore: response.hasMore,
         currentPage: nextPage,
       ));
     } catch (e) {
       emit(state.copyWith(errorMessage: e.toString()));
+    } finally {
+      _isLoadingMore = false;
     }
   }
 }

--- a/lib/presentation/blocs/friend/friend_bloc.dart
+++ b/lib/presentation/blocs/friend/friend_bloc.dart
@@ -177,7 +177,13 @@ class FriendBloc extends Bloc<FriendEvent, FriendState> {
     FriendRequestAccepted event,
     Emitter<FriendState> emit,
   ) async {
-    emit(state.copyWith(clearErrorMessage: true));
+    // 같은 요청이 이미 처리 중이면 더블탭 중복 호출을 무시한다.
+    if (state.processingRequestIds.contains(event.requestId)) return;
+
+    emit(state.copyWith(
+      clearErrorMessage: true,
+      processingRequestIds: {...state.processingRequestIds, event.requestId},
+    ));
     try {
       await _friendRepository.acceptFriendRequest(event.requestId);
       final friends = await _friendRepository.getFriends();
@@ -189,9 +195,15 @@ class FriendBloc extends Bloc<FriendEvent, FriendState> {
         friends: visibleFriends,
         receivedRequests: receivedRequests,
         clearErrorMessage: true,
+        processingRequestIds:
+            _without(state.processingRequestIds, event.requestId),
       ));
     } catch (e) {
-      emit(state.copyWith(errorMessage: _extractErrorMessage(e)));
+      emit(state.copyWith(
+        errorMessage: _extractErrorMessage(e),
+        processingRequestIds:
+            _without(state.processingRequestIds, event.requestId),
+      ));
     }
   }
 
@@ -199,17 +211,35 @@ class FriendBloc extends Bloc<FriendEvent, FriendState> {
     FriendRequestRejected event,
     Emitter<FriendState> emit,
   ) async {
-    emit(state.copyWith(clearErrorMessage: true));
+    // 같은 요청이 이미 처리 중이면 더블탭 중복 호출을 무시한다.
+    if (state.processingRequestIds.contains(event.requestId)) return;
+
+    emit(state.copyWith(
+      clearErrorMessage: true,
+      processingRequestIds: {...state.processingRequestIds, event.requestId},
+    ));
     try {
       await _friendRepository.rejectFriendRequest(event.requestId);
       final receivedRequests = await _friendRepository.getReceivedFriendRequests();
       emit(state.copyWith(
         receivedRequests: receivedRequests,
         clearErrorMessage: true,
+        processingRequestIds:
+            _without(state.processingRequestIds, event.requestId),
       ));
     } catch (e) {
-      emit(state.copyWith(errorMessage: _extractErrorMessage(e)));
+      emit(state.copyWith(
+        errorMessage: _extractErrorMessage(e),
+        processingRequestIds:
+            _without(state.processingRequestIds, event.requestId),
+      ));
     }
+  }
+
+  Set<int> _without(Set<int> ids, int id) {
+    final next = {...ids};
+    next.remove(id);
+    return next;
   }
 
   Future<void> _onRemoved(

--- a/lib/presentation/blocs/friend/friend_state.dart
+++ b/lib/presentation/blocs/friend/friend_state.dart
@@ -20,6 +20,11 @@ class FriendState extends Equatable {
   final bool isBlockedUsersLoading;
   final String? successMessage;
 
+  /// 처리 중인 친구요청 ID 집합. 수락/거절이 in-flight 인 동안 해당 ID 가 들어
+  /// 있어, 같은 요청에 대한 더블탭 중복 호출(→ 409/400 거짓 에러)을 막고
+  /// UI 가 버튼을 비활성/스피너 처리할 수 있게 한다.
+  final Set<int> processingRequestIds;
+
   const FriendState({
     this.status = FriendStatus.initial,
     this.friends = const [],
@@ -35,6 +40,7 @@ class FriendState extends Equatable {
     this.isHiddenFriendsLoading = false,
     this.isBlockedUsersLoading = false,
     this.successMessage,
+    this.processingRequestIds = const {},
   });
 
   FriendState copyWith({
@@ -55,6 +61,7 @@ class FriendState extends Equatable {
     bool? isBlockedUsersLoading,
     String? successMessage,
     bool clearSuccessMessage = false,
+    Set<int>? processingRequestIds,
   }) {
     return FriendState(
       status: status ?? this.status,
@@ -71,6 +78,7 @@ class FriendState extends Equatable {
       isHiddenFriendsLoading: isHiddenFriendsLoading ?? this.isHiddenFriendsLoading,
       isBlockedUsersLoading: isBlockedUsersLoading ?? this.isBlockedUsersLoading,
       successMessage: clearSuccessMessage ? null : (successMessage ?? this.successMessage),
+      processingRequestIds: processingRequestIds ?? this.processingRequestIds,
     );
   }
 
@@ -90,5 +98,6 @@ class FriendState extends Equatable {
         isHiddenFriendsLoading,
         isBlockedUsersLoading,
         successMessage,
+        processingRequestIds,
       ];
 }

--- a/lib/presentation/pages/chat/chat_list_page.dart
+++ b/lib/presentation/pages/chat/chat_list_page.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -269,14 +270,24 @@ class _ChatRoomTile extends StatelessWidget {
 
   const _ChatRoomTile({required this.chatRoom, required this.displayName});
 
+  /// 아바타는 작은 원형으로만 표시되므로 디스크 캐시 + 다운샘플(maxWidth)을
+  /// 적용해 raw NetworkImage 의 풀해상도 디코딩/재다운로드를 막는다.
+  static const int _avatarCacheWidth = 200;
+
   ImageProvider? _getAvatarImage(ChatRoom chatRoom) {
     // 1:1 채팅 - 상대방 아바타
     if (chatRoom.type == ChatRoomType.direct && chatRoom.otherUserAvatarUrl != null) {
-      return NetworkImage(chatRoom.otherUserAvatarUrl!);
+      return CachedNetworkImageProvider(
+        chatRoom.otherUserAvatarUrl!,
+        maxWidth: _avatarCacheWidth,
+      );
     }
     // 그룹 채팅 - 그룹 이미지
     if (chatRoom.type == ChatRoomType.group && chatRoom.imageUrl != null) {
-      return NetworkImage(chatRoom.imageUrl!);
+      return CachedNetworkImageProvider(
+        chatRoom.imageUrl!,
+        maxWidth: _avatarCacheWidth,
+      );
     }
     return null;
   }

--- a/lib/presentation/pages/chat/media_gallery_page.dart
+++ b/lib/presentation/pages/chat/media_gallery_page.dart
@@ -179,30 +179,49 @@ class _MediaTabContent extends StatelessWidget {
   }
 
   Widget _buildPhotoGrid(List<MediaGalleryItem> items) {
-    return GridView.builder(
-      padding: const EdgeInsets.all(2),
-      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: 3,
-        crossAxisSpacing: 2,
-        mainAxisSpacing: 2,
-      ),
-      itemCount: items.length,
-      itemBuilder: (context, index) {
-        final item = items[index];
-        return GestureDetector(
-          onTap: () => _showFullScreenImage(context, item),
-          child: CachedNetworkImage(
-            imageUrl: item.thumbnailUrl ?? item.fileUrl ?? '',
-            fit: BoxFit.cover,
-            placeholder: (_, __) => Container(
-              color: Colors.grey[200],
-              child: const Center(child: CircularProgressIndicator(strokeWidth: 2)),
-            ),
-            errorWidget: (_, __, ___) => Container(
-              color: Colors.grey[200],
-              child: const Icon(Icons.broken_image, color: Colors.grey),
-            ),
+    return Builder(
+      builder: (context) {
+        // 그리드 셀은 화면 너비를 3등분한 작은 영역만 차지한다. thumbnailUrl 이
+        // null 이면 원본(fileUrl)을 그대로 디코딩하게 되어 풀해상도 비트맵이
+        // 메모리에 상주(OOM 위험)하므로, 셀 폭 * devicePixelRatio 로
+        // memCacheWidth 를 지정해 다운샘플링한다. (전체화면 뷰어는 풀해상도 유지)
+        const crossAxisCount = 3;
+        const spacing = 2.0;
+        final mq = MediaQuery.of(context);
+        final gridWidth = mq.size.width - 4; // padding(2) * 2
+        final cellWidth =
+            (gridWidth - spacing * (crossAxisCount - 1)) / crossAxisCount;
+        final cellCacheWidth = (cellWidth * mq.devicePixelRatio).round();
+
+        return GridView.builder(
+          padding: const EdgeInsets.all(2),
+          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: crossAxisCount,
+            crossAxisSpacing: spacing,
+            mainAxisSpacing: spacing,
           ),
+          itemCount: items.length,
+          itemBuilder: (context, index) {
+            final item = items[index];
+            return GestureDetector(
+              onTap: () => _showFullScreenImage(context, item),
+              child: CachedNetworkImage(
+                imageUrl: item.thumbnailUrl ?? item.fileUrl ?? '',
+                fit: BoxFit.cover,
+                memCacheWidth: cellCacheWidth,
+                placeholder: (_, __) => Container(
+                  color: Colors.grey[200],
+                  child: const Center(
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                ),
+                errorWidget: (_, __, ___) => Container(
+                  color: Colors.grey[200],
+                  child: const Icon(Icons.broken_image, color: Colors.grey),
+                ),
+              ),
+            );
+          },
         );
       },
     );

--- a/lib/presentation/pages/chat/media_gallery_page.dart
+++ b/lib/presentation/pages/chat/media_gallery_page.dart
@@ -183,15 +183,20 @@ class _MediaTabContent extends StatelessWidget {
       builder: (context) {
         // 그리드 셀은 화면 너비를 3등분한 작은 영역만 차지한다. thumbnailUrl 이
         // null 이면 원본(fileUrl)을 그대로 디코딩하게 되어 풀해상도 비트맵이
-        // 메모리에 상주(OOM 위험)하므로, 셀 폭 * devicePixelRatio 로
-        // memCacheWidth 를 지정해 다운샘플링한다. (전체화면 뷰어는 풀해상도 유지)
+        // 메모리에 상주(OOM 위험)하므로, 셀 크기 * devicePixelRatio 로
+        // memCacheWidth/Height 를 함께 지정해 다운샘플링한다.
+        // 셀은 정사각형(childAspectRatio 기본값 1.0)이고 BoxFit.cover 로 채우므로
+        // 높이 한계를 지정하지 않으면 세로가 긴 원본의 비트맵 높이가 원본
+        // 종횡비를 따라 커진다. → 폭/높이 모두 셀 한 변 기준으로 제한한다.
+        // (전체화면 뷰어는 풀해상도 유지)
         const crossAxisCount = 3;
         const spacing = 2.0;
         final mq = MediaQuery.of(context);
         final gridWidth = mq.size.width - 4; // padding(2) * 2
         final cellWidth =
             (gridWidth - spacing * (crossAxisCount - 1)) / crossAxisCount;
-        final cellCacheWidth = (cellWidth * mq.devicePixelRatio).round();
+        // 셀은 정사각형이므로 한 변(cellWidth)을 폭·높이 캐시 한계로 공용한다.
+        final cellCacheExtent = (cellWidth * mq.devicePixelRatio).round();
 
         return GridView.builder(
           padding: const EdgeInsets.all(2),
@@ -208,7 +213,8 @@ class _MediaTabContent extends StatelessWidget {
               child: CachedNetworkImage(
                 imageUrl: item.thumbnailUrl ?? item.fileUrl ?? '',
                 fit: BoxFit.cover,
-                memCacheWidth: cellCacheWidth,
+                memCacheWidth: cellCacheExtent,
+                memCacheHeight: cellCacheExtent,
                 placeholder: (_, __) => Container(
                   color: Colors.grey[200],
                   child: const Center(

--- a/lib/presentation/pages/chat/widgets/message_bubble.dart
+++ b/lib/presentation/pages/chat/widgets/message_bubble.dart
@@ -1167,7 +1167,10 @@ class MessageBubble extends StatelessWidget {
                       radius: 18,
                       backgroundColor: AppColors.primaryLight,
                       backgroundImage: message.senderAvatarUrl != null
-                          ? NetworkImage(message.senderAvatarUrl!)
+                          ? CachedNetworkImageProvider(
+                              message.senderAvatarUrl!,
+                              maxWidth: 200,
+                            )
                           : null,
                       child: message.senderAvatarUrl == null
                           ? Text(

--- a/lib/presentation/pages/friends/blocked_users_page.dart
+++ b/lib/presentation/pages/friends/blocked_users_page.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -187,7 +188,10 @@ class _BlockedUserTile extends StatelessWidget {
             radius: 28,
             backgroundColor: AppColors.primaryLight,
             backgroundImage: user.avatarUrl != null
-                ? NetworkImage(user.avatarUrl!)
+                ? CachedNetworkImageProvider(
+                    user.avatarUrl!,
+                    maxWidth: 200,
+                  )
                 : null,
             child: user.avatarUrl == null
                 ? Text(

--- a/lib/presentation/pages/friends/friend_list_page.dart
+++ b/lib/presentation/pages/friends/friend_list_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
@@ -278,7 +279,7 @@ class _MyProfileCard extends StatelessWidget {
               radius: 35,
               backgroundColor: AppColors.primaryLight,
               backgroundImage: user.avatarUrl != null
-                  ? NetworkImage(user.avatarUrl!)
+                  ? CachedNetworkImageProvider(user.avatarUrl!, maxWidth: 200)
                   : null,
               child: user.avatarUrl == null
                   ? Text(
@@ -376,7 +377,10 @@ class _FriendTile extends StatelessWidget {
                     radius: 28,
                     backgroundColor: AppColors.primaryLight,
                     backgroundImage: friend.user.avatarUrl != null
-                        ? NetworkImage(friend.user.avatarUrl!)
+                        ? CachedNetworkImageProvider(
+                            friend.user.avatarUrl!,
+                            maxWidth: 200,
+                          )
                         : null,
                     child: friend.user.avatarUrl == null
                         ? Text(
@@ -791,7 +795,10 @@ class _AddFriendBottomSheetState extends State<_AddFriendBottomSheet> {
                                 radius: 28,
                                 backgroundColor: AppColors.primaryLight,
                                 backgroundImage: user.avatarUrl != null
-                                    ? NetworkImage(user.avatarUrl!)
+                                    ? CachedNetworkImageProvider(
+                                        user.avatarUrl!,
+                                        maxWidth: 200,
+                                      )
                                     : null,
                                 child: user.avatarUrl == null
                                     ? Text(

--- a/lib/presentation/pages/friends/hidden_friends_page.dart
+++ b/lib/presentation/pages/friends/hidden_friends_page.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -165,7 +166,10 @@ class _HiddenFriendTile extends StatelessWidget {
             radius: 28,
             backgroundColor: AppColors.primaryLight,
             backgroundImage: friend.user.avatarUrl != null
-                ? NetworkImage(friend.user.avatarUrl!)
+                ? CachedNetworkImageProvider(
+                    friend.user.avatarUrl!,
+                    maxWidth: 200,
+                  )
                 : null,
             child: friend.user.avatarUrl == null
                 ? Text(

--- a/lib/presentation/pages/friends/received_requests_page.dart
+++ b/lib/presentation/pages/friends/received_requests_page.dart
@@ -141,7 +141,11 @@ class _ReceivedRequestsView extends StatelessWidget {
                 ),
                 itemBuilder: (context, index) {
                   final request = state.receivedRequests[index];
-                  return _ReceivedRequestTile(request: request);
+                  return _ReceivedRequestTile(
+                    request: request,
+                    isProcessing:
+                        state.processingRequestIds.contains(request.id),
+                  );
                 },
               ),
             );
@@ -154,8 +158,12 @@ class _ReceivedRequestsView extends StatelessWidget {
 
 class _ReceivedRequestTile extends StatelessWidget {
   final FriendRequest request;
+  final bool isProcessing;
 
-  const _ReceivedRequestTile({required this.request});
+  const _ReceivedRequestTile({
+    required this.request,
+    this.isProcessing = false,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -210,13 +218,18 @@ class _ReceivedRequestTile extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               OutlinedButton(
-                onPressed: () {
-                  // 거절은 가벼운 '선택' 피드백(selection), 수락은 더 분명한
-                  // light() 로 의도적으로 차별화한다. 긍정 액션(수락)에 더 또렷한
-                  // 촉감을 주어 두 버튼의 결과를 손끝으로 구분할 수 있게 한다.
-                  AppHaptics.selection();
-                  context.read<FriendBloc>().add(FriendRequestRejected(request.id));
-                },
+                // 처리 중에는 비활성화하여 더블탭 중복 호출(거짓 에러)을 막는다.
+                onPressed: isProcessing
+                    ? null
+                    : () {
+                        // 거절은 가벼운 '선택' 피드백(selection), 수락은 더 분명한
+                        // light() 로 의도적으로 차별화한다. 긍정 액션(수락)에 더
+                        // 또렷한 촉감을 주어 두 버튼의 결과를 손끝으로 구분한다.
+                        AppHaptics.selection();
+                        context
+                            .read<FriendBloc>()
+                            .add(FriendRequestRejected(request.id));
+                      },
                 style: OutlinedButton.styleFrom(
                   foregroundColor: AppColors.textSecondary,
                   side: BorderSide(color: AppColors.divider),
@@ -229,10 +242,15 @@ class _ReceivedRequestTile extends StatelessWidget {
               ),
               const SizedBox(width: 8),
               ElevatedButton(
-                onPressed: () {
-                  AppHaptics.light();
-                  context.read<FriendBloc>().add(FriendRequestAccepted(request.id));
-                },
+                // 처리 중에는 비활성화하여 더블탭 중복 호출(거짓 에러)을 막는다.
+                onPressed: isProcessing
+                    ? null
+                    : () {
+                        AppHaptics.light();
+                        context
+                            .read<FriendBloc>()
+                            .add(FriendRequestAccepted(request.id));
+                      },
                 style: ElevatedButton.styleFrom(
                   backgroundColor: AppColors.primary,
                   foregroundColor: Colors.white,
@@ -241,7 +259,17 @@ class _ReceivedRequestTile extends StatelessWidget {
                     vertical: 8,
                   ),
                 ),
-                child: const Text('수락'),
+                child: isProcessing
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          valueColor:
+                              AlwaysStoppedAnimation<Color>(Colors.white),
+                        ),
+                      )
+                    : const Text('수락'),
               ),
             ],
           ),

--- a/lib/presentation/pages/friends/received_requests_page.dart
+++ b/lib/presentation/pages/friends/received_requests_page.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -175,7 +176,10 @@ class _ReceivedRequestTile extends StatelessWidget {
             radius: 28,
             backgroundColor: AppColors.primaryLight,
             backgroundImage: request.requester.avatarUrl != null
-                ? NetworkImage(request.requester.avatarUrl!)
+                ? CachedNetworkImageProvider(
+                    request.requester.avatarUrl!,
+                    maxWidth: 200,
+                  )
                 : null,
             child: request.requester.avatarUrl == null
                 ? Text(

--- a/lib/presentation/pages/friends/sent_requests_page.dart
+++ b/lib/presentation/pages/friends/sent_requests_page.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -166,7 +167,10 @@ class _SentRequestTile extends StatelessWidget {
             radius: 28,
             backgroundColor: AppColors.primaryLight,
             backgroundImage: request.receiver.avatarUrl != null
-                ? NetworkImage(request.receiver.avatarUrl!)
+                ? CachedNetworkImageProvider(
+                    request.receiver.avatarUrl!,
+                    maxWidth: 200,
+                  )
                 : null,
             child: request.receiver.avatarUrl == null
                 ? Text(

--- a/lib/presentation/pages/profile/profile_page.dart
+++ b/lib/presentation/pages/profile/profile_page.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
@@ -52,7 +53,10 @@ class ProfilePage extends StatelessWidget {
                           radius: 60,
                           backgroundColor: AppColors.primaryLight,
                           backgroundImage: user.avatarUrl != null
-                              ? NetworkImage(user.avatarUrl!)
+                              ? CachedNetworkImageProvider(
+                                  user.avatarUrl!,
+                                  maxWidth: 400,
+                                )
                               : null,
                           child: user.avatarUrl == null
                               ? Text(

--- a/lib/presentation/pages/profile/widgets/profile_image_section.dart
+++ b/lib/presentation/pages/profile/widgets/profile_image_section.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import '../../../../core/theme/app_colors.dart';
 
@@ -55,7 +56,10 @@ class ProfileImageSection extends StatelessWidget {
                     backgroundImage: selectedImage != null
                         ? FileImage(selectedImage!)
                         : avatarUrl != null
-                            ? NetworkImage(avatarUrl!) as ImageProvider
+                            ? CachedNetworkImageProvider(
+                                avatarUrl!,
+                                maxWidth: 400,
+                              ) as ImageProvider
                             : null,
                     child: (selectedImage == null && avatarUrl == null)
                         ? Text(

--- a/test/blocs/friend_bloc_test.dart
+++ b/test/blocs/friend_bloc_test.dart
@@ -192,6 +192,96 @@ void main() {
       );
     });
 
+    group('Friend request in-flight guard (4th-review P3)', () {
+      blocTest<FriendBloc, FriendState>(
+        'ignores a duplicate accept for the same requestId while in flight',
+        build: () {
+          when(() => mockFriendRepository.acceptFriendRequest(any()))
+              .thenAnswer((_) async {
+            await Future.delayed(const Duration(milliseconds: 50));
+          });
+          when(() => mockFriendRepository.getFriends())
+              .thenAnswer((_) async => FakeEntities.friends);
+          when(() => mockFriendRepository.getReceivedFriendRequests())
+              .thenAnswer((_) async => FakeEntities.receivedFriendRequests);
+          return FriendBloc(mockFriendRepository, mockWebSocketService);
+        },
+        act: (bloc) {
+          // Double tap before the first accept resolves.
+          bloc.add(const FriendRequestAccepted(1));
+          bloc.add(const FriendRequestAccepted(1));
+        },
+        wait: const Duration(milliseconds: 150),
+        verify: (bloc) {
+          // The repository must be hit only once — no 409/400 false error.
+          verify(() => mockFriendRepository.acceptFriendRequest(1)).called(1);
+          expect(bloc.state.processingRequestIds, isEmpty);
+        },
+      );
+
+      blocTest<FriendBloc, FriendState>(
+        'marks requestId as processing while accept is in flight',
+        build: () {
+          when(() => mockFriendRepository.acceptFriendRequest(any()))
+              .thenAnswer((_) async {
+            await Future.delayed(const Duration(milliseconds: 50));
+          });
+          when(() => mockFriendRepository.getFriends())
+              .thenAnswer((_) async => FakeEntities.friends);
+          when(() => mockFriendRepository.getReceivedFriendRequests())
+              .thenAnswer((_) async => FakeEntities.receivedFriendRequests);
+          return FriendBloc(mockFriendRepository, mockWebSocketService);
+        },
+        act: (bloc) => bloc.add(const FriendRequestAccepted(7)),
+        wait: const Duration(milliseconds: 150),
+        expect: () => [
+          // First emit marks 7 as processing (button should disable).
+          isA<FriendState>()
+              .having((s) => s.processingRequestIds, 'processing', contains(7)),
+          // Final emit clears the processing flag.
+          isA<FriendState>()
+              .having((s) => s.processingRequestIds, 'processing', isEmpty)
+              .having((s) => s.status, 'status', FriendStatus.success),
+        ],
+      );
+
+      blocTest<FriendBloc, FriendState>(
+        'ignores a duplicate reject for the same requestId while in flight',
+        build: () {
+          when(() => mockFriendRepository.rejectFriendRequest(any()))
+              .thenAnswer((_) async {
+            await Future.delayed(const Duration(milliseconds: 50));
+          });
+          when(() => mockFriendRepository.getReceivedFriendRequests())
+              .thenAnswer((_) async => FakeEntities.receivedFriendRequests);
+          return FriendBloc(mockFriendRepository, mockWebSocketService);
+        },
+        act: (bloc) {
+          bloc.add(const FriendRequestRejected(1));
+          bloc.add(const FriendRequestRejected(1));
+        },
+        wait: const Duration(milliseconds: 150),
+        verify: (bloc) {
+          verify(() => mockFriendRepository.rejectFriendRequest(1)).called(1);
+          expect(bloc.state.processingRequestIds, isEmpty);
+        },
+      );
+
+      blocTest<FriendBloc, FriendState>(
+        'clears processing flag and reports error when accept fails',
+        build: () {
+          when(() => mockFriendRepository.acceptFriendRequest(any()))
+              .thenThrow(Exception('boom'));
+          return FriendBloc(mockFriendRepository, mockWebSocketService);
+        },
+        act: (bloc) => bloc.add(const FriendRequestAccepted(3)),
+        verify: (bloc) {
+          expect(bloc.state.processingRequestIds, isEmpty);
+          expect(bloc.state.errorMessage, isNotNull);
+        },
+      );
+    });
+
     group('FriendRemoved', () {
       blocTest<FriendBloc, FriendState>(
         'removes friend and updates list',

--- a/test/blocs/friend_event_state_test.dart
+++ b/test/blocs/friend_event_state_test.dart
@@ -294,7 +294,8 @@ void main() {
         searchQuery: 'test',
       );
 
-      expect(state.props.length, 14);
+      // 15 = 기존 14개 필드 + processingRequestIds (4차 점검 P3 더블탭 가드)
+      expect(state.props.length, 15);
     });
 
     test('can update hasSearched', () {

--- a/test/blocs/media_gallery_bloc_test.dart
+++ b/test/blocs/media_gallery_bloc_test.dart
@@ -581,6 +581,41 @@ void main() {
           );
         },
       );
+
+      blocTest<MediaGalleryBloc, MediaGalleryState>(
+        'collapses intra-page duplicates within a single response',
+        seed: () => MediaGalleryState(
+          status: MediaGalleryStatus.success,
+          items: [testItem1],
+          nextCursor: 100,
+          hasMore: true,
+          currentPage: 0,
+          currentType: MediaType.photo,
+          roomId: 1,
+        ),
+        build: () {
+          when(() => mockChatRemoteDataSource.getMediaGallery(
+                any(),
+                any(),
+                page: any(named: 'page'),
+              )).thenAnswer((_) async => MediaGalleryResponse(
+                    // The same response page repeats testItem2 twice.
+                    items: [testItem2, testItem2, testItem3],
+                    nextCursor: 200,
+                    hasMore: true,
+                  ));
+          return createBloc();
+        },
+        act: (bloc) => bloc.add(const MediaGalleryLoadMoreRequested()),
+        verify: (bloc) {
+          // testItem2 must appear once even though the page repeated it.
+          expect(bloc.state.items.length, 3);
+          expect(
+            bloc.state.items.where((i) => i.messageId == testItem2.messageId).length,
+            1,
+          );
+        },
+      );
     });
 
     group('Edge cases', () {

--- a/test/blocs/media_gallery_bloc_test.dart
+++ b/test/blocs/media_gallery_bloc_test.dart
@@ -501,6 +501,88 @@ void main() {
       );
     });
 
+    group('Concurrent load-more guard (4th-review P2)', () {
+      blocTest<MediaGalleryBloc, MediaGalleryState>(
+        'fetches next page only once when two LoadMore arrive concurrently',
+        seed: () => MediaGalleryState(
+          status: MediaGalleryStatus.success,
+          items: [testItem1],
+          nextCursor: 100,
+          hasMore: true,
+          currentPage: 0,
+          currentType: MediaType.photo,
+          roomId: 1,
+        ),
+        build: () {
+          when(() => mockChatRemoteDataSource.getMediaGallery(
+                any(),
+                any(),
+                page: any(named: 'page'),
+              )).thenAnswer((_) async {
+            await Future.delayed(const Duration(milliseconds: 50));
+            return MediaGalleryResponse(
+              items: [testItem2],
+              nextCursor: 200,
+              hasMore: true,
+            );
+          });
+          return createBloc();
+        },
+        act: (bloc) {
+          // Two rapid scroll-end events before the first fetch completes.
+          bloc.add(const MediaGalleryLoadMoreRequested());
+          bloc.add(const MediaGalleryLoadMoreRequested());
+        },
+        wait: const Duration(milliseconds: 200),
+        verify: (bloc) {
+          // Only one network call for page 1 — the second event is dropped.
+          verify(() => mockChatRemoteDataSource.getMediaGallery(
+                1,
+                MediaType.photo,
+                page: 1,
+              )).called(1);
+          // No duplicate item appended.
+          expect(bloc.state.items.length, 2);
+          expect(bloc.state.currentPage, 1);
+        },
+      );
+
+      blocTest<MediaGalleryBloc, MediaGalleryState>(
+        'never appends an item whose messageId already exists',
+        seed: () => MediaGalleryState(
+          status: MediaGalleryStatus.success,
+          items: [testItem1],
+          nextCursor: 100,
+          hasMore: true,
+          currentPage: 0,
+          currentType: MediaType.photo,
+          roomId: 1,
+        ),
+        build: () {
+          when(() => mockChatRemoteDataSource.getMediaGallery(
+                any(),
+                any(),
+                page: any(named: 'page'),
+              )).thenAnswer((_) async => MediaGalleryResponse(
+                    // Server returns an overlapping item (testItem1) plus a new one.
+                    items: [testItem1, testItem2],
+                    nextCursor: 200,
+                    hasMore: true,
+                  ));
+          return createBloc();
+        },
+        act: (bloc) => bloc.add(const MediaGalleryLoadMoreRequested()),
+        verify: (bloc) {
+          // testItem1 must not be duplicated.
+          expect(bloc.state.items.length, 2);
+          expect(
+            bloc.state.items.where((i) => i.messageId == testItem1.messageId).length,
+            1,
+          );
+        },
+      );
+    });
+
     group('Edge cases', () {
       blocTest<MediaGalleryBloc, MediaGalleryState>(
         'handles large list of items',

--- a/test/pages/chat_list_page_test.dart
+++ b/test/pages/chat_list_page_test.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -142,6 +143,37 @@ void main() {
       expect(find.text('OtherUser'), findsOneWidget);
       expect(find.text('안녕하세요'), findsOneWidget);
       expect(find.text('5'), findsOneWidget);
+    });
+
+    testWidgets(
+        'avatar uses CachedNetworkImageProvider (cached + downsampled), '
+        'not raw NetworkImage (P3)', (tester) async {
+      final chatRooms = [
+        ChatRoom(
+          id: 1,
+          name: null,
+          type: ChatRoomType.direct,
+          createdAt: DateTime(2024, 1, 1),
+          unreadCount: 0,
+          otherUserId: 2,
+          otherUserNickname: 'OtherUser',
+          otherUserAvatarUrl: 'https://example.com/avatar.png',
+        ),
+      ];
+
+      when(() => mockChatListBloc.state).thenReturn(
+        ChatListState(
+          status: ChatListStatus.success,
+          chatRooms: chatRooms,
+        ),
+      );
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pump();
+
+      final avatar = tester.widget<CircleAvatar>(find.byType(CircleAvatar));
+      expect(avatar.backgroundImage, isA<CachedNetworkImageProvider>());
+      expect(avatar.backgroundImage, isNot(isA<NetworkImage>()));
     });
 
     testWidgets('shows 99+ for high unread count', (tester) async {

--- a/test/pages/media_gallery_page_test.dart
+++ b/test/pages/media_gallery_page_test.dart
@@ -1,0 +1,87 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:co_talk_flutter/data/models/media_gallery_model.dart';
+import 'package:co_talk_flutter/di/injection.dart';
+import 'package:co_talk_flutter/presentation/blocs/chat/media_gallery_bloc.dart';
+import 'package:co_talk_flutter/presentation/pages/chat/media_gallery_page.dart';
+
+class MockMediaGalleryBloc
+    extends MockBloc<MediaGalleryEvent, MediaGalleryState>
+    implements MediaGalleryBloc {}
+
+void main() {
+  late MockMediaGalleryBloc mockBloc;
+
+  setUp(() {
+    mockBloc = MockMediaGalleryBloc();
+    if (getIt.isRegistered<MediaGalleryBloc>()) {
+      getIt.unregister<MediaGalleryBloc>();
+    }
+    getIt.registerFactory<MediaGalleryBloc>(() => mockBloc);
+  });
+
+  tearDown(() {
+    if (getIt.isRegistered<MediaGalleryBloc>()) {
+      getIt.unregister<MediaGalleryBloc>();
+    }
+  });
+
+  // thumbnailUrl 이 null 인 사진 항목 — 풀해상도 원본(fileUrl)을 작은 그리드
+  // 셀에 디코딩하므로 memCacheWidth 다운샘플링이 반드시 필요한 OOM 케이스.
+  final photoNoThumb = MediaGalleryItem(
+    messageId: 1,
+    type: 'IMAGE',
+    fileUrl: 'https://example.com/full_resolution.jpg',
+    thumbnailUrl: null,
+    contentType: 'image/jpeg',
+    createdAt: DateTime(2024, 1, 1),
+    senderId: 100,
+  );
+
+  Widget createWidget() {
+    return const MaterialApp(
+      home: MediaGalleryPage(roomId: 1),
+    );
+  }
+
+  testWidgets(
+    'photo grid sets memCacheWidth to downsample full-resolution images (P2 OOM)',
+    (tester) async {
+      whenListen(
+        mockBloc,
+        const Stream<MediaGalleryState>.empty(),
+        initialState: MediaGalleryState(
+          status: MediaGalleryStatus.success,
+          items: [photoNoThumb],
+          hasMore: false,
+          currentPage: 0,
+          currentType: MediaType.photo,
+          roomId: 1,
+        ),
+      );
+
+      await tester.pumpWidget(createWidget());
+      await tester.pump();
+
+      // The first tab (photo) renders the grid. Every CachedNetworkImage in
+      // the grid must carry a non-null, bounded memCacheWidth so that the
+      // raw origin is downsampled instead of decoded at full resolution.
+      final gridImages = tester
+          .widgetList<CachedNetworkImage>(find.byType(CachedNetworkImage))
+          .where((img) => img.imageUrl == photoNoThumb.fileUrl)
+          .toList();
+
+      expect(gridImages, isNotEmpty);
+      for (final img in gridImages) {
+        expect(img.memCacheWidth, isNotNull,
+            reason: 'grid cell image must specify memCacheWidth');
+        expect(img.memCacheWidth! > 0, isTrue);
+        // Sanity: cache width should be a small cell, well under a 4K origin.
+        expect(img.memCacheWidth! < 4000, isTrue);
+      }
+    },
+  );
+}

--- a/test/pages/media_gallery_page_test.dart
+++ b/test/pages/media_gallery_page_test.dart
@@ -80,6 +80,16 @@ void main() {
         expect(img.memCacheWidth! > 0, isTrue);
         // Sanity: cache width should be a small cell, well under a 4K origin.
         expect(img.memCacheWidth! < 4000, isTrue);
+
+        // A BoxFit.cover square cell must also bound the decoded height,
+        // otherwise a tall portrait origin keeps a large bitmap whose height
+        // follows the original aspect ratio (P3 memory regression).
+        expect(img.memCacheHeight, isNotNull,
+            reason: 'grid cell image must specify memCacheHeight');
+        expect(img.memCacheHeight! > 0, isTrue);
+        expect(img.memCacheHeight! < 4000, isTrue);
+        // Square cell => height bound should equal the width bound.
+        expect(img.memCacheHeight, img.memCacheWidth);
       }
     },
   );

--- a/test/pages/media_gallery_page_test.dart
+++ b/test/pages/media_gallery_page_test.dart
@@ -1,7 +1,6 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:co_talk_flutter/data/models/media_gallery_model.dart';
 import 'package:co_talk_flutter/di/injection.dart';

--- a/test/pages/received_requests_page_test.dart
+++ b/test/pages/received_requests_page_test.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:co_talk_flutter/presentation/blocs/friend/friend_bloc.dart';
+import 'package:co_talk_flutter/presentation/blocs/friend/friend_event.dart';
+import 'package:co_talk_flutter/presentation/blocs/friend/friend_state.dart';
+import 'package:co_talk_flutter/presentation/pages/friends/received_requests_page.dart';
+import 'package:co_talk_flutter/di/injection.dart';
+import '../mocks/fake_entities.dart';
+
+class MockFriendBloc extends MockBloc<FriendEvent, FriendState>
+    implements FriendBloc {}
+
+void main() {
+  late MockFriendBloc mockFriendBloc;
+
+  setUp(() {
+    mockFriendBloc = MockFriendBloc();
+    if (getIt.isRegistered<FriendBloc>()) {
+      getIt.unregister<FriendBloc>();
+    }
+    getIt.registerFactory<FriendBloc>(() => mockFriendBloc);
+  });
+
+  tearDown(() {
+    if (getIt.isRegistered<FriendBloc>()) {
+      getIt.unregister<FriendBloc>();
+    }
+  });
+
+  Widget createWidget() {
+    return const MaterialApp(home: ReceivedRequestsPage());
+  }
+
+  ElevatedButton acceptButton(WidgetTester tester) =>
+      tester.widget<ElevatedButton>(find.byType(ElevatedButton));
+  OutlinedButton rejectButton(WidgetTester tester) =>
+      tester.widget<OutlinedButton>(find.byType(OutlinedButton));
+
+  testWidgets('accept/reject enabled when request is not processing',
+      (tester) async {
+    when(() => mockFriendBloc.state).thenReturn(
+      FriendState(
+        receivedRequests: FakeEntities.receivedFriendRequests,
+      ),
+    );
+
+    await tester.pumpWidget(createWidget());
+    await tester.pump();
+
+    expect(acceptButton(tester).onPressed, isNotNull);
+    expect(rejectButton(tester).onPressed, isNotNull);
+  });
+
+  testWidgets(
+      'accept/reject disabled and spinner shown while request is in flight '
+      '(P3 double-tap guard)', (tester) async {
+    final request = FakeEntities.receivedFriendRequests.first;
+    when(() => mockFriendBloc.state).thenReturn(
+      FriendState(
+        receivedRequests: FakeEntities.receivedFriendRequests,
+        processingRequestIds: {request.id},
+      ),
+    );
+
+    await tester.pumpWidget(createWidget());
+    await tester.pump();
+
+    // Both buttons disabled so a second tap cannot fire a duplicate event.
+    expect(acceptButton(tester).onPressed, isNull);
+    expect(rejectButton(tester).onPressed, isNull);
+    // Accept button shows an in-flight spinner instead of the label.
+    expect(
+      find.descendant(
+        of: find.byType(ElevatedButton),
+        matching: find.byType(CircularProgressIndicator),
+      ),
+      findsOneWidget,
+    );
+  });
+}


### PR DESCRIPTION
## 배경 (4차 점검)

- **[P2] 갤러리 load-more 가드 무효 → 중복 fetch**: load-more 가드가 `status==loading` 만 검사했으나 load-more 는 status 를 바꾸지 않아 무효. 빠른 스크롤 시 두 LoadMore 가 같은 페이지를 중복 fetch + dedup 없이 concat → 미디어 중복 표시.
- **[P2 성능] 갤러리 그리드 memCacheWidth 누락 → OOM**: `_buildPhotoGrid` 의 `CachedNetworkImage` 에 memCacheWidth 가 없어 thumbnailUrl 이 null 이면 원본 풀해상도를 작은 셀에 디코딩.
- **[P3] 친구요청 수락/거절 더블탭 거짓 에러**: 인플라이트 가드/스피너 없이 매 탭 add → 더블탭 시 같은 requestId 중복 호출, 둘째가 409/400 → 성공인데 빨간 에러 스낵바.
- **[P3 성능] 아바타 raw NetworkImage**: 아바타가 디스크 캐시·다운샘플 없는 raw NetworkImage. chat_list 는 buildWhen 없어 매 WS 이벤트마다 재생성.

## 변경

1. **MediaGalleryBloc**: in-flight 플래그(`_isLoadingMore`)로 동시 load-more 두 번째 이벤트 드롭 + messageId 기준 dedup.
2. **media_gallery_page**: 그리드 셀 `CachedNetworkImage` 에 `memCacheWidth`(셀폭×dpr) 추가. 전체화면 뷰어(InteractiveViewer)는 풀해상도 유지.
3. **FriendBloc/State + received_requests_page**: `processingRequestIds` 집합으로 처리 중 동일 requestId 무시 + 버튼 비활성화/수락 스피너.
4. **아바타 통일**: chat_list / message_bubble / friends(hidden·list·received·sent·blocked) / profile(page·image_section) 아바타를 `CachedNetworkImageProvider`(+maxWidth)로 교체.

## 검증

- `flutter analyze`: **No issues found (0)**
- `flutter test`: **전체 1785 통과 (-0)**
- 추가 테스트: 동시 load-more 1회만 fetch / 중복 messageId 미추가 / 그리드 memCacheWidth 설정 / 친구요청 인플라이트 중복 차단·플래그 해제·버튼 비활성화 / chat_list 아바타 CachedNetworkImageProvider 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)