### PR TITLE
fix: Flutter 클라이언트 보안/정확성 수정 (C1 인증서 피닝, H1 clientMessageId, H2 sending 상태)

### DIFF
--- a/lib/core/config/security_config.dart
+++ b/lib/core/config/security_config.dart
@@ -5,6 +5,11 @@ import 'app_config.dart';
 class SecurityConfig {
   SecurityConfig._();
 
+  /// 자리표시자(placeholder) 핀 값. 실제 핀이 설정되지 않았음을 나타낸다.
+  /// 이 값이 핀 목록에 남아 있으면 production-ready가 아니다.
+  static const String placeholderPin =
+      '0000000000000000000000000000000000000000000000000000000000000000';
+
   /// Certificate pinning enabled flag
   /// Disabled in development for easier testing
   /// Should be enabled in production
@@ -17,43 +22,49 @@ class SecurityConfig {
     return AppConfig.isProduction;
   }
 
-  /// List of pinned certificate SHA-256 fingerprints
+  /// List of pinned certificate SHA-256 fingerprints (서버 인증서 DER의 SHA-256, hex).
   ///
-  /// IMPORTANT: Replace these placeholder values with actual server certificate fingerprints
-  /// before deploying to production.
+  /// IMPORTANT: 프로덕션 배포 전에 placeholder 값을 실제 서버 인증서 지문으로 교체해야 한다.
+  /// 인증서 로테이션을 지원하기 위해 여러 핀(현재 + 차기 인증서)을 함께 등록할 수 있다.
   ///
-  /// To get the SHA-256 fingerprint of your server certificate:
+  /// 서버 인증서(전체 인증서)의 SHA-256(hex) 지문을 얻는 방법:
   /// ```bash
   /// openssl s_client -connect your-server.com:443 -servername your-server.com \
-  ///   | openssl x509 -pubkey -noout \
-  ///   | openssl pkey -pubin -outform der \
-  ///   | openssl dgst -sha256 -binary \
-  ///   | openssl enc -base64
-  /// ```
-  ///
-  /// Or using the DER format:
-  /// ```bash
-  /// openssl x509 -in certificate.crt -pubkey -noout \
-  ///   | openssl pkey -pubin -outform der \
+  ///   </dev/null 2>/dev/null \
+  ///   | openssl x509 -outform der \
   ///   | openssl dgst -sha256 -hex
   /// ```
   ///
-  /// Store multiple certificates to support certificate rotation.
+  /// 참고: 더 견고한 방식은 공개키(SPKI) 핀이지만, Dart의 X509Certificate는
+  /// 공개키/SPKI를 직접 노출하지 않아(ASN.1 파싱 필요) 여기서는 인증서 전체
+  /// DER의 SHA-256으로 핀을 비교한다. 인증서 로테이션 시 핀도 함께 갱신해야 한다.
+  ///
+  /// 실제 핀이 정해지면 환경별로 주입하거나 아래 목록을 교체한다.
   static const List<String> pinnedCertificates = [
-    // TODO: Replace with actual server certificate SHA-256 fingerprint
-    // Example format: 'a1b2c3d4e5f6789012345678901234567890123456789012345678901234567890'
-    '0000000000000000000000000000000000000000000000000000000000000000', // Placeholder
+    // TODO: 실제 서버 인증서 SHA-256(hex) 지문으로 교체. 예:
+    // 'a1b2c3d4e5f6789012345678901234567890123456789012345678901234567890',
+    placeholderPin, // Placeholder — 실제 핀이 설정되지 않음
   ];
 
-  /// Validates if the configuration is production-ready
+  /// 실제(비-placeholder) 핀이 하나라도 설정되어 있는지 여부.
+  static bool get hasRealPin =>
+      pinnedCertificates.any((p) => p.toLowerCase() != placeholderPin);
+
+  /// 인증서 피닝이 실제로 동작 가능한 상태인지 여부.
+  /// (피닝이 켜져 있고 실제 핀이 설정된 경우에만 true)
+  static bool get isPinningActive => certificatePinningEnabled && hasRealPin;
+
+  /// Validates if the configuration is production-ready.
+  ///
+  /// 피닝이 활성화(프로덕션)된 경우에는 실제 핀이 설정되어 있어야만 true.
+  /// 자리표시자 핀만 있으면 보호가 전혀 없으므로 false(거짓 production-ready 신호 제거).
   static bool get isProductionReady {
     if (!certificatePinningEnabled) {
-      return true; // OK if disabled (development)
+      // 개발/디버그: 피닝이 의도적으로 비활성화됨.
+      return true;
     }
-    // Check if placeholder certificate is still in use
-    return !pinnedCertificates.contains(
-      '0000000000000000000000000000000000000000000000000000000000000000',
-    );
+    // 프로덕션: 실제 핀이 설정되어 있을 때에만 production-ready.
+    return hasRealPin;
   }
 
   /// Warning message for production deployment

--- a/lib/core/network/auth_interceptor.dart
+++ b/lib/core/network/auth_interceptor.dart
@@ -1,15 +1,18 @@
 import 'package:dio/dio.dart';
+import 'package:dio/io.dart';
 import 'package:flutter/foundation.dart';
 import 'package:injectable/injectable.dart';
 import '../constants/api_constants.dart';
 import '../../data/datasources/local/auth_local_datasource.dart';
 import '../../presentation/blocs/auth/auth_bloc.dart';
 import '../../presentation/blocs/auth/auth_event.dart';
+import 'certificate_pinning_interceptor.dart';
 import 'websocket_service.dart';
 
 @lazySingleton
 class AuthInterceptor extends QueuedInterceptor {
   final AuthLocalDataSource _authLocalDataSource;
+  final CertificatePinningService _certificatePinningService;
   AuthBloc? _authBloc;
   WebSocketService? _webSocketService;
 
@@ -30,11 +33,8 @@ class AuthInterceptor extends QueuedInterceptor {
   @visibleForTesting
   Dio get refreshDio => _refreshDio;
 
-  AuthInterceptor(this._authLocalDataSource) {
+  AuthInterceptor(this._authLocalDataSource, this._certificatePinningService) {
     // 토큰 갱신 전용 클라이언트 생성 (인터셉터 없이)
-    // TODO: When real certificate pinning is enabled (non-placeholder certificates),
-    // add CertificatePinningInterceptor to _refreshDio to prevent MITM attacks
-    // during token refresh requests
     _refreshDio = Dio(
       BaseOptions(
         baseUrl: ApiConstants.apiBaseUrl,
@@ -46,6 +46,10 @@ class AuthInterceptor extends QueuedInterceptor {
           'Accept': 'application/json',
         },
       ),
+    );
+    // 토큰 갱신 요청도 동일한 인증서 피닝을 적용해 refresh 중 MITM을 방지한다.
+    _refreshDio.httpClientAdapter = IOHttpClientAdapter(
+      createHttpClient: _certificatePinningService.createPinnedHttpClient,
     );
   }
 

--- a/lib/core/network/certificate_pinning_interceptor.dart
+++ b/lib/core/network/certificate_pinning_interceptor.dart
@@ -1,114 +1,74 @@
 import 'dart:io';
 
-import 'package:dio/dio.dart';
+import 'package:crypto/crypto.dart';
 import 'package:flutter/foundation.dart';
 import 'package:injectable/injectable.dart';
 import '../config/security_config.dart';
 
-/// Dio interceptor for certificate pinning
+/// 인증서 피닝 서비스.
 ///
-/// This interceptor validates SSL/TLS certificates against a list of
-/// pinned certificate fingerprints to prevent man-in-the-middle attacks.
+/// SSL/TLS 인증서를 설정된 핀(서버 인증서 DER의 SHA-256 지문) 목록과 비교해
+/// 중간자(MITM) 공격을 방지한다.
 ///
-/// Only active when [SecurityConfig.certificatePinningEnabled] is true.
+/// 사용 방식: [createPinnedHttpClient]가 반환하는 [HttpClient]를 Dio의
+/// `IOHttpClientAdapter(createHttpClient: ...)`에 연결한다. 이렇게 해야
+/// [HttpClient.badCertificateCallback]이 실제 TLS 핸드셰이크 검증에 사용된다.
+/// (과거 구현은 Dio의 plain Interceptor로 등록되어 콜백이 호출되지 않는
+/// 보안상 무의미한 코드였다.)
+///
+/// [SecurityConfig.isPinningActive]가 true일 때에만 실제 핀 검증을 수행한다.
 @lazySingleton
-class CertificatePinningInterceptor extends Interceptor {
-  HttpClient? _httpClient;
+class CertificatePinningService {
+  const CertificatePinningService();
 
-  CertificatePinningInterceptor() {
-    if (SecurityConfig.certificatePinningEnabled) {
-      _initializeHttpClient();
-    }
+  /// 인증서 DER 바이트의 SHA-256 지문(소문자 hex)을 계산한다.
+  static String sha256OfDer(List<int> der) {
+    return sha256.convert(der).toString();
   }
 
-  void _initializeHttpClient() {
-    _httpClient = HttpClient()
-      ..badCertificateCallback = (X509Certificate cert, String host, int port) {
-        // Validate certificate against pinned fingerprints
-        return _validateCertificate(cert);
-      };
-  }
-
-  bool _validateCertificate(X509Certificate cert) {
+  /// [cert]가 설정된 핀 중 하나와 일치하는지 검증한다.
+  ///
+  /// 피닝이 비활성(개발/디버그)이면 모든 인증서를 허용한다.
+  /// 핀이 설정되지 않았으면(실제 핀 없음) 보호가 없으므로 거부한다.
+  static bool isCertificateValid(X509Certificate cert) {
     if (!SecurityConfig.certificatePinningEnabled) {
-      return true; // Allow all certificates when pinning is disabled
+      return true; // 개발/디버그: 핀 검증을 수행하지 않음
     }
 
-    if (SecurityConfig.pinnedCertificates.isEmpty) {
+    if (!SecurityConfig.hasRealPin) {
       if (kDebugMode) {
         debugPrint(
-          'WARNING: Certificate pinning is enabled but no certificates are configured',
+          'WARNING: Certificate pinning is enabled but no real pin is configured',
         );
       }
       return false;
     }
 
-    // Extract SHA-256 fingerprint from certificate
-    final certSha256 = _getSha256Fingerprint(cert);
-
-    // Check if certificate matches any pinned fingerprint
-    final isValid = SecurityConfig.pinnedCertificates.any(
-      (pinnedFingerprint) =>
-          pinnedFingerprint.toLowerCase() == certSha256.toLowerCase(),
-    );
+    final fingerprint = sha256OfDer(cert.der).toLowerCase();
+    final isValid = SecurityConfig.pinnedCertificates
+        .any((pin) => pin.toLowerCase() == fingerprint);
 
     if (!isValid && kDebugMode) {
-      debugPrint('Certificate verification failed for host: ${cert.subject}');
-      debugPrint('Certificate SHA-256: $certSha256');
-      debugPrint(
-        'Pinned fingerprints: ${SecurityConfig.pinnedCertificates}',
-      );
+      debugPrint('Certificate pinning failed for: ${cert.subject}');
+      debugPrint('Presented SHA-256: $fingerprint');
     }
 
     return isValid;
   }
 
-  String _getSha256Fingerprint(X509Certificate cert) {
-    // Get DER-encoded certificate
-    final derCert = cert.der;
-
-    // Calculate SHA-256 hash
-    // Note: For public key pinning (more secure), we would hash only the public key
-    // For now, we're doing certificate pinning (full certificate hash)
-    final sha256Hash = _calculateSha256(derCert);
-
-    // Convert to hex string
-    return sha256Hash;
-  }
-
-  String _calculateSha256(Uint8List data) {
-    // Use a simple hex conversion
-    // For production, consider using crypto package for proper SHA-256
-    return data
-        .map((byte) => byte.toRadixString(16).padLeft(2, '0'))
-        .join('')
-        .toLowerCase();
-  }
-
-  @override
-  void onError(DioException err, ErrorInterceptorHandler handler) {
-    if (err.type == DioExceptionType.badCertificate ||
-        err.error is HandshakeException) {
-      if (kDebugMode) {
-        debugPrint('Certificate pinning error: ${err.message}');
-      }
-
-      // Create a user-friendly error
-      final error = DioException(
-        requestOptions: err.requestOptions,
-        error:
-            'Certificate verification failed: Server certificate does not match pinned certificates',
-        type: DioExceptionType.badCertificate,
-      );
-
-      handler.next(error);
-      return;
+  /// 피닝이 적용된 [HttpClient]를 생성한다.
+  ///
+  /// [SecurityConfig.isPinningActive]가 true일 때에만
+  /// [HttpClient.badCertificateCallback]을 설정해 핀 검증을 수행한다.
+  /// 피닝이 비활성이면 기본 동작(시스템 신뢰 저장소)을 그대로 사용한다.
+  HttpClient createPinnedHttpClient([HttpClient? client]) {
+    final httpClient = client ?? HttpClient();
+    if (SecurityConfig.isPinningActive) {
+      httpClient.badCertificateCallback =
+          (X509Certificate cert, String host, int port) {
+        return isCertificateValid(cert);
+      };
     }
-
-    handler.next(err);
-  }
-
-  void dispose() {
-    _httpClient?.close();
+    return httpClient;
   }
 }

--- a/lib/core/network/dio_client.dart
+++ b/lib/core/network/dio_client.dart
@@ -1,7 +1,7 @@
 import 'package:dio/dio.dart';
+import 'package:dio/io.dart';
 import 'package:injectable/injectable.dart';
 import '../config/app_config.dart';
-import '../config/security_config.dart';
 import '../constants/api_constants.dart';
 import 'auth_interceptor.dart';
 import 'certificate_pinning_interceptor.dart';
@@ -10,11 +10,11 @@ import 'certificate_pinning_interceptor.dart';
 class DioClient {
   late final Dio _dio;
   final AuthInterceptor _authInterceptor;
-  final CertificatePinningInterceptor _certificatePinningInterceptor;
+  final CertificatePinningService _certificatePinningService;
 
   DioClient(
     this._authInterceptor,
-    this._certificatePinningInterceptor,
+    this._certificatePinningService,
   ) {
     _dio = Dio(
       BaseOptions(
@@ -29,10 +29,12 @@ class DioClient {
       ),
     );
 
-    // Add certificate pinning interceptor first for security
-    if (SecurityConfig.certificatePinningEnabled) {
-      _dio.interceptors.add(_certificatePinningInterceptor);
-    }
+    // 인증서 피닝: HttpClientAdapter에 연결해야 badCertificateCallback이 실제
+    // TLS 핸드셰이크 검증에 사용된다. (plain Interceptor로 등록하면 콜백이
+    // 호출되지 않아 무의미하다.) 피닝이 비활성이면 기본 HttpClient를 사용한다.
+    _dio.httpClientAdapter = IOHttpClientAdapter(
+      createHttpClient: _certificatePinningService.createPinnedHttpClient,
+    );
 
     _dio.interceptors.add(_authInterceptor);
 

--- a/lib/core/network/websocket/websocket_events.dart
+++ b/lib/core/network/websocket/websocket_events.dart
@@ -43,6 +43,11 @@ class WebSocketChatMessage {
   final int? relatedUserId;
   final String? relatedUserNickname;
 
+  /// 클라이언트가 전송 시 부여한 메시지 ID(UUID). 백엔드가 echo에 되돌려주면
+  /// 낙관적 전송 메시지를 정확히 매칭/교체하는 데 사용된다 (H1).
+  /// 백엔드 미지원 시 null (기존 content+window fallback 동작).
+  final String? clientMessageId;
+
   WebSocketChatMessage({
     this.schemaVersion,
     this.eventId,
@@ -65,6 +70,7 @@ class WebSocketChatMessage {
     this.eventType,
     this.relatedUserId,
     this.relatedUserNickname,
+    this.clientMessageId,
   });
 
   factory WebSocketChatMessage.fromJson(Map<String, dynamic> json, int roomId) {
@@ -90,6 +96,8 @@ class WebSocketChatMessage {
       eventType: json['eventType'] as String?,
       relatedUserId: json['relatedUserId'] as int?,
       relatedUserNickname: json['relatedUserNickname'] as String?,
+      // 백엔드 echo가 clientMessageId를 실어 보내면 정확 매칭에 사용 (없으면 null).
+      clientMessageId: json['clientMessageId'] as String?,
     );
   }
 

--- a/lib/core/network/websocket/websocket_message_sender.dart
+++ b/lib/core/network/websocket/websocket_message_sender.dart
@@ -22,6 +22,7 @@ class WebSocketMessageSender {
     required StompClient? stompClient,
     required int roomId,
     required String content,
+    String? clientMessageId,
   }) {
     if (stompClient == null || !stompClient.connected) {
       if (kDebugMode) {
@@ -35,6 +36,12 @@ class WebSocketMessageSender {
       body: jsonEncode({
         'roomId': roomId,
         'content': content,
+        // 낙관적 전송 중복제거용 클라이언트 메시지 ID(UUID).
+        // 백엔드는 broadcast/echo 메시지에 이 값을 그대로 다시 실어 보내야
+        // 클라이언트가 content+시간 매칭이 아닌 정확한 ID 매칭으로 pending
+        // 메시지를 교체할 수 있다. (백엔드 echo 미지원 시에도 무해 — 기존
+        // content+window fallback으로 동작한다. 백엔드 PR 예정.)
+        if (clientMessageId != null) 'clientMessageId': clientMessageId,
       }),
     );
     return true;

--- a/lib/core/network/websocket_service.dart
+++ b/lib/core/network/websocket_service.dart
@@ -261,11 +261,13 @@ class WebSocketService {
   bool sendMessage({
     required int roomId,
     required String content,
+    String? clientMessageId,
   }) {
     return _messageSender.sendMessage(
       stompClient: _connectionManager.stompClient,
       roomId: roomId,
       content: content,
+      clientMessageId: clientMessageId,
     );
   }
 

--- a/lib/di/injection.config.dart
+++ b/lib/di/injection.config.dart
@@ -100,8 +100,8 @@ extension GetItInjectableX on _i174.GetIt {
     gh.singleton<_i60.WebSocketPayloadParser>(
       () => const _i60.WebSocketPayloadParser(),
     );
-    gh.lazySingleton<_i206.CertificatePinningInterceptor>(
-      () => _i206.CertificatePinningInterceptor(),
+    gh.lazySingleton<_i206.CertificatePinningService>(
+      () => const _i206.CertificatePinningService(),
     );
     gh.lazySingleton<_i480.ActiveRoomTracker>(() => _i480.ActiveRoomTracker());
     gh.lazySingleton<_i507.AppBadgeService>(() => _i507.AppBadgeService());
@@ -128,6 +128,12 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i860.AuthLocalDataSource>(
       () => _i860.AuthLocalDataSourceImpl(gh<_i558.FlutterSecureStorage>()),
     );
+    gh.lazySingleton<_i552.AuthInterceptor>(
+      () => _i552.AuthInterceptor(
+        gh<_i860.AuthLocalDataSource>(),
+        gh<_i206.CertificatePinningService>(),
+      ),
+    );
     gh.lazySingleton<_i809.FcmService>(
       () => _i809.NoOpFcmService(),
       registerFor: {_desktop},
@@ -141,9 +147,6 @@ extension GetItInjectableX on _i174.GetIt {
       () => _i64.NotificationLocalDataSourceImpl(
         gh<_i558.FlutterSecureStorage>(),
       ),
-    );
-    gh.lazySingleton<_i552.AuthInterceptor>(
-      () => _i552.AuthInterceptor(gh<_i860.AuthLocalDataSource>()),
     );
     gh.factory<_i884.BiometricSettingsCubit>(
       () => _i884.BiometricSettingsCubit(
@@ -161,12 +164,6 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i601.ChatLocalDataSource>(
       () => _i601.ChatLocalDataSourceImpl(gh<_i441.AppDatabase>()),
     );
-    gh.lazySingleton<_i393.DioClient>(
-      () => _i393.DioClient(
-        gh<_i552.AuthInterceptor>(),
-        gh<_i206.CertificatePinningInterceptor>(),
-      ),
-    );
     gh.lazySingleton<_i570.NotificationService>(
       () => _i570.NotificationService(
         plugin: gh<_i163.FlutterLocalNotificationsPlugin>(),
@@ -182,19 +179,14 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i860.AuthLocalDataSource>(),
       ),
     );
-    gh.lazySingleton<_i991.SettingsRemoteDataSource>(
-      () => _i991.SettingsRemoteDataSourceImpl(gh<_i393.DioClient>()),
-    );
-    gh.lazySingleton<_i577.LinkPreviewRemoteDataSource>(
-      () => _i577.LinkPreviewRemoteDataSourceImpl(gh<_i393.DioClient>()),
+    gh.lazySingleton<_i393.DioClient>(
+      () => _i393.DioClient(
+        gh<_i552.AuthInterceptor>(),
+        gh<_i206.CertificatePinningService>(),
+      ),
     );
     gh.lazySingleton<_i738.ReportRemoteDataSource>(
       () => _i738.ReportRemoteDataSourceImpl(gh<_i393.DioClient>()),
-    );
-    gh.lazySingleton<_i1014.LinkPreviewRepository>(
-      () => _i319.LinkPreviewRepositoryImpl(
-        gh<_i577.LinkPreviewRemoteDataSource>(),
-      ),
     );
     gh.lazySingleton<_i633.AuthRemoteDataSource>(
       () => _i633.AuthRemoteDataSourceImpl(gh<_i393.DioClient>()),
@@ -232,12 +224,6 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i860.AuthLocalDataSource>(),
       ),
     );
-    gh.lazySingleton<_i977.SettingsRepository>(
-      () => _i453.SettingsRepositoryImpl(
-        gh<_i991.SettingsRemoteDataSource>(),
-        gh<_i30.ChatSettingsLocalDataSource>(),
-      ),
-    );
     gh.factory<_i389.EmailVerificationBloc>(
       () => _i389.EmailVerificationBloc(gh<_i800.AuthRepository>()),
     );
@@ -250,14 +236,19 @@ extension GetItInjectableX on _i174.GetIt {
     gh.factory<_i487.MessageSearchBloc>(
       () => _i487.MessageSearchBloc(gh<_i792.ChatRepository>()),
     );
-    gh.lazySingleton<_i110.ChatSettingsCubit>(
-      () => _i110.ChatSettingsCubit(gh<_i977.SettingsRepository>()),
-    );
-    gh.lazySingleton<_i728.NotificationSettingsCubit>(
-      () => _i728.NotificationSettingsCubit(gh<_i977.SettingsRepository>()),
-    );
     gh.lazySingleton<_i217.ProfileRepository>(
       () => _i953.ProfileRepositoryImpl(gh<_i710.ProfileRemoteDataSource>()),
+    );
+    gh.lazySingleton<_i991.SettingsRemoteDataSource>(
+      () => _i991.SettingsRemoteDataSourceImpl(gh<_i393.DioClient>()),
+    );
+    gh.lazySingleton<_i577.LinkPreviewRemoteDataSource>(
+      () => _i577.LinkPreviewRemoteDataSourceImpl(gh<_i393.DioClient>()),
+    );
+    gh.lazySingleton<_i1014.LinkPreviewRepository>(
+      () => _i319.LinkPreviewRepositoryImpl(
+        gh<_i577.LinkPreviewRemoteDataSource>(),
+      ),
     );
     gh.lazySingleton<_i995.ChatListBloc>(
       () => _i995.ChatListBloc(
@@ -272,6 +263,24 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i1069.FriendRepository>(),
         gh<_i682.WebSocketService>(),
       ),
+    );
+    gh.lazySingleton<_i977.SettingsRepository>(
+      () => _i453.SettingsRepositoryImpl(
+        gh<_i991.SettingsRemoteDataSource>(),
+        gh<_i30.ChatSettingsLocalDataSource>(),
+      ),
+    );
+    gh.factory<_i256.ProfileBloc>(
+      () => _i256.ProfileBloc(
+        gh<_i217.ProfileRepository>(),
+        gh<_i800.AuthRepository>(),
+      ),
+    );
+    gh.lazySingleton<_i110.ChatSettingsCubit>(
+      () => _i110.ChatSettingsCubit(gh<_i977.SettingsRepository>()),
+    );
+    gh.lazySingleton<_i728.NotificationSettingsCubit>(
+      () => _i728.NotificationSettingsCubit(gh<_i977.SettingsRepository>()),
     );
     gh.factory<_i870.ChangePasswordBloc>(
       () => _i870.ChangePasswordBloc(gh<_i977.SettingsRepository>()),
@@ -304,12 +313,6 @@ extension GetItInjectableX on _i174.GetIt {
         webSocketService: gh<_i682.WebSocketService>(),
         windowFocusTracker: gh<_i156.WindowFocusTracker>(),
         settingsRepository: gh<_i977.SettingsRepository>(),
-      ),
-    );
-    gh.factory<_i256.ProfileBloc>(
-      () => _i256.ProfileBloc(
-        gh<_i217.ProfileRepository>(),
-        gh<_i800.AuthRepository>(),
       ),
     );
     gh.factory<_i995.ChatRoomBloc>(

--- a/lib/domain/entities/message.dart
+++ b/lib/domain/entities/message.dart
@@ -4,9 +4,16 @@ enum MessageType { text, image, file, system }
 
 /// 메시지 전송 상태 (카카오톡 스타일 UI용)
 enum MessageSendStatus {
-  /// 전송 중 (로딩 표시)
+  /// 전송 대기 (로컬 큐에 추가됨, WS send() 호출 전/직후 ~ 서버 확인 전)
   pending,
-  /// 전송 완료 (읽지 않음 개수 표시)
+  /// 전송 중 (WS send() 호출은 끝났으나 서버 echo/ack 미수신 — 로딩 표시)
+  ///
+  /// stompClient.send()는 ack를 반환하지 않으므로, send() 직후에는 서버가
+  /// 메시지를 수신했다는 보장이 없다. 따라서 echo/ack가 오기 전까지는
+  /// [sent]가 아닌 [sending] 상태로 두고, echo 수신 시 [sent]로 승격한다.
+  /// (15초 pending-timeout 체커가 실패 백스톱으로 [failed]로 전환한다.)
+  sending,
+  /// 전송 완료 (서버 echo/ack 확인됨 — 읽지 않음 개수 표시)
   sent,
   /// 전송 실패 (재전송/삭제 버튼 표시)
   failed,
@@ -74,8 +81,12 @@ class Message extends Equatable {
     this.localId,
   });
 
-  /// pending 메시지인지 확인
-  bool get isPending => sendStatus == MessageSendStatus.pending;
+  /// 아직 서버 확인(echo/ack)을 받지 못한 미확정 메시지인지 확인.
+  /// [pending](전송 대기)과 [sending](send() 호출 후 echo 대기) 모두 포함한다.
+  /// 로딩 인디케이터 표시 및 전송 타임아웃 백스톱 대상이다.
+  bool get isPending =>
+      sendStatus == MessageSendStatus.pending ||
+      sendStatus == MessageSendStatus.sending;
 
   /// 전송 실패 메시지인지 확인
   bool get isFailed => sendStatus == MessageSendStatus.failed;

--- a/lib/presentation/blocs/chat/chat_room_bloc.dart
+++ b/lib/presentation/blocs/chat/chat_room_bloc.dart
@@ -926,6 +926,9 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
       roomId: roomId,
       content: content,
       userId: userId,
+      // localId를 clientMessageId로 함께 전송 → 서버가 echo에 되돌려주면
+      // content+시간이 아닌 정확한 ID로 pending 메시지를 매칭/교체한다 (H1).
+      clientMessageId: localId,
     ).then((_) {
       if (!isClosed) {
         add(MessageSendCompleted(localId: localId, success: true));
@@ -947,12 +950,15 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
     Emitter<ChatRoomState> emit,
   ) {
     if (event.success) {
-      _log('_onMessageSendCompleted: sent (localId=${event.localId})');
-      // 전송 성공 → 즉시 "sent" 상태로 변경 (에코를 기다리지 않음).
-      // 에코가 오면 _onMessageReceived에서 서버 메시지로 교체.
+      _log('_onMessageSendCompleted: sending (localId=${event.localId})');
+      // WS send()는 ack를 반환하지 않는다. send() 호출이 끝났다고 해서 서버가
+      // 메시지를 받았다는 보장은 없으므로 아직 "sent"로 표시하지 않는다.
+      // 서버 echo가 _onMessageReceived → replacePendingMessageWithReal에서
+      // 도착하면 그때 "sent"로 승격한다. echo가 끝내 오지 않으면 15초
+      // pending-timeout 체커가 "failed"로 전환한다.
       _cacheManager.updatePendingMessageStatus(
         event.localId,
-        MessageSendStatus.sent,
+        MessageSendStatus.sending,
       );
       emit(state.copyWith(messages: _cacheManager.messages));
     } else {

--- a/lib/presentation/blocs/chat/managers/message_cache_manager.dart
+++ b/lib/presentation/blocs/chat/managers/message_cache_manager.dart
@@ -383,33 +383,60 @@ class MessageCacheManager {
   /// - pending messages waiting for echo
   /// - messages already marked as "sent" via fire-and-forget
   ///
-  /// Matching criteria:
-  /// - Locally originated (negative ID)
-  /// - Same content
-  /// - Created within 60 seconds of the real message
-  /// - If multiple matches, select the OLDEST one (FIFO)
+  /// Matching strategy (H1):
+  /// 1) PREFER exact match by clientMessageId: 서버 echo가 clientMessageId를
+  ///    실어 보내면([realMessage.localId]에 담김), 동일한 localId를 가진
+  ///    로컬 메시지를 정확히 교체한다. 동일 내용("ㅇㅇ" 등) 메시지가 여러 개
+  ///    pending 상태여도 올바른 버블을 교체한다.
+  /// 2) FALLBACK by content + 시간 window: echo에 clientMessageId가 없을 때만
+  ///    (백엔드 미지원) 기존 방식으로 매칭한다.
+  ///    - Locally originated (negative ID)
+  ///    - Same content
+  ///    - Created within 60 seconds of the real message
+  ///    - If multiple matches, select the OLDEST one (FIFO)
+  ///
+  /// NOTE(backend): 정확 매칭을 위해 백엔드가 broadcast/echo 메시지에
+  /// `clientMessageId`를 그대로 되돌려줘야 한다 (백엔드 PR 예정). 그 전까지는
+  /// fallback이 동작하므로 무회귀(no-regression) 개선이다.
   bool replacePendingMessageWithReal(String content, Message realMessage) {
-    final matchingIndices = <int>[];
-    const maxTimeDiff = Duration(seconds: 60);
+    final maxTimeDiff = const Duration(seconds: 60);
+    int? localIndex;
 
-    for (int i = 0; i < _messages.length; i++) {
-      final m = _messages[i];
-      // Match locally-originated messages (negative temp ID) with same content
-      if (m.id < 0 && m.content == content) {
-        final timeDiff = realMessage.createdAt.difference(m.createdAt).abs();
-        if (timeDiff <= maxTimeDiff) {
-          matchingIndices.add(i);
+    // 1) clientMessageId(=localId) 정확 매칭 우선.
+    final echoedClientMessageId = realMessage.localId;
+    if (echoedClientMessageId != null) {
+      for (int i = 0; i < _messages.length; i++) {
+        final m = _messages[i];
+        if (m.id < 0 && m.localId == echoedClientMessageId) {
+          localIndex = i;
+          break;
         }
       }
     }
 
-    if (matchingIndices.isEmpty) {
-      return false;
+    // 2) clientMessageId가 없거나 매칭 실패 시 content+window fallback.
+    if (localIndex == null) {
+      final matchingIndices = <int>[];
+      for (int i = 0; i < _messages.length; i++) {
+        final m = _messages[i];
+        // Match locally-originated messages (negative temp ID) with same content
+        if (m.id < 0 && m.content == content) {
+          final timeDiff = realMessage.createdAt.difference(m.createdAt).abs();
+          if (timeDiff <= maxTimeDiff) {
+            matchingIndices.add(i);
+          }
+        }
+      }
+
+      if (matchingIndices.isEmpty) {
+        return false;
+      }
+
+      // Select the OLDEST matching local message (FIFO ordering)
+      // Since messages are added at the beginning, the oldest is at the highest index
+      localIndex = matchingIndices.reduce((a, b) => a > b ? a : b);
     }
 
-    // Select the OLDEST matching local message (FIFO ordering)
-    // Since messages are added at the beginning, the oldest is at the highest index
-    final localIndex = matchingIndices.reduce((a, b) => a > b ? a : b);
     final localMessage = _messages[localIndex];
 
     _log('Replacing local message (localId=${localMessage.localId}) with real message (id=${realMessage.id})');

--- a/lib/presentation/blocs/chat/managers/message_handler.dart
+++ b/lib/presentation/blocs/chat/managers/message_handler.dart
@@ -43,6 +43,7 @@ class MessageHandler {
     required int roomId,
     required String content,
     int? userId,
+    String? clientMessageId,
   }) async {
     if (userId == null) {
       userId = await _authLocalDataSource.getUserId();
@@ -69,6 +70,7 @@ class MessageHandler {
     var success = _webSocketService.sendMessage(
       roomId: roomId,
       content: content,
+      clientMessageId: clientMessageId,
     );
 
     // Retry once: the STOMP connection may have dropped between isConnected
@@ -82,6 +84,7 @@ class MessageHandler {
         success = _webSocketService.sendMessage(
           roomId: roomId,
           content: content,
+          clientMessageId: clientMessageId,
         );
       }
       if (!success) {

--- a/lib/presentation/blocs/chat/managers/websocket_subscription_manager.dart
+++ b/lib/presentation/blocs/chat/managers/websocket_subscription_manager.dart
@@ -175,6 +175,9 @@ class WebSocketSubscriptionManager {
       replyToMessageId: wsMessage.replyToMessageId,
       forwardedFromMessageId: wsMessage.forwardedFromMessageId,
       unreadCount: wsMessage.unreadCount,
+      // 서버 echo가 clientMessageId를 실어 보내면 localId 슬롯에 담아
+      // replacePendingMessageWithReal가 정확 ID 매칭에 사용한다 (H1).
+      localId: wsMessage.clientMessageId,
     );
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -290,7 +290,7 @@ packages:
     source: hosted
     version: "0.3.5+1"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
   dio: ^5.7.0
   http_parser: ^4.0.0
   json_annotation: ^4.9.0
+  # 인증서 피닝: 인증서 DER의 SHA-256 지문 계산에 사용 (C1)
+  crypto: ^3.0.0
 
   # WebSocket (STOMP)
   stomp_dart_client: ^2.0.0

--- a/test/blocs/chat_room_bloc_test.dart
+++ b/test/blocs/chat_room_bloc_test.dart
@@ -101,6 +101,7 @@ void main() {
     when(() => mockWebSocketService.sendMessage(
           roomId: any(named: 'roomId'),
           content: any(named: 'content'),
+              clientMessageId: any(named: 'clientMessageId'),
         )).thenReturn(true);
     when(() => mockWebSocketService.sendPresenceInactive(
           roomId: any(named: 'roomId'),
@@ -556,17 +557,63 @@ void main() {
               .having((s) => s.messages.first.content, 'content', '안녕하세요!')
               .having((s) => s.messages.first.sendStatus, 'sendStatus', MessageSendStatus.pending)
               .having((s) => s.messages.first.senderId, 'senderId', 42),
-          // 2. Fire-and-forget 전송 성공 → 즉시 sent로 전환
+          // 2. Fire-and-forget send() 성공 → 서버 echo 전이므로 sending (H2).
+          //    sent로의 승격은 echo 수신 시(_onMessageReceived)에만 일어난다.
           isA<ChatRoomState>()
               .having((s) => s.messages.length, 'messages length', 1)
               .having((s) => s.messages.first.content, 'content', '안녕하세요!')
-              .having((s) => s.messages.first.sendStatus, 'sendStatus', MessageSendStatus.sent),
+              .having((s) => s.messages.first.sendStatus, 'sendStatus', MessageSendStatus.sending),
         ],
         verify: (_) {
           verify(() => mockWebSocketService.sendMessage(
                 roomId: 1,
                 content: '안녕하세요!',
+                clientMessageId: any(named: 'clientMessageId'),
               )).called(1);
+        },
+      );
+
+      // ── H2: send() 후 sending, echo 수신 후에만 sent ──────────────────
+      blocTest<ChatRoomBloc, ChatRoomState>(
+        'message is `sending` after send() returns and only `sent` after '
+        'the echo arrives',
+        build: () {
+          when(() => mockAuthLocalDataSource.getUserId())
+              .thenAnswer((_) async => 42);
+          return createBloc();
+        },
+        seed: () => const ChatRoomState(
+          status: ChatRoomStatus.success,
+          roomId: 1,
+          currentUserId: 42,
+          messages: [],
+        ),
+        act: (bloc) async {
+          // 1) 전송 → fire-and-forget send() 완료 후 sending 이어야 한다.
+          bloc.add(const MessageSent('ping'));
+          await Future.delayed(const Duration(milliseconds: 100));
+
+          final pending = bloc.state.messages.first;
+          expect(pending.sendStatus, MessageSendStatus.sending,
+              reason: 'send() 직후에는 ack가 없으므로 sent가 아닌 sending이어야 한다');
+
+          // 2) 서버 echo 도착(clientMessageId=localId 포함) → 이제서야 sent 승격.
+          bloc.add(MessageReceived(Message(
+            id: 9001,
+            chatRoomId: 1,
+            senderId: 42,
+            content: 'ping',
+            createdAt: DateTime.now(),
+            localId: pending.localId,
+          )));
+          await Future.delayed(const Duration(milliseconds: 100));
+        },
+        verify: (bloc) {
+          final confirmed =
+              bloc.state.messages.firstWhere((m) => m.content == 'ping');
+          expect(confirmed.id, 9001);
+          expect(confirmed.sendStatus, MessageSendStatus.sent,
+              reason: 'echo 수신 후에만 sent로 승격돼야 한다');
         },
       );
 
@@ -585,6 +632,7 @@ void main() {
           verifyNever(() => mockWebSocketService.sendMessage(
                 roomId: any(named: 'roomId'),
                 content: any(named: 'content'),
+                    clientMessageId: any(named: 'clientMessageId'),
               ));
         },
       );
@@ -595,6 +643,7 @@ void main() {
           when(() => mockWebSocketService.sendMessage(
                 roomId: any(named: 'roomId'),
                 content: any(named: 'content'),
+                    clientMessageId: any(named: 'clientMessageId'),
               )).thenThrow(Exception('Network error'));
           when(() => mockAuthLocalDataSource.getUserId())
               .thenAnswer((_) async => 42);
@@ -629,6 +678,7 @@ void main() {
           verifyNever(() => mockWebSocketService.sendMessage(
                 roomId: any(named: 'roomId'),
                 content: any(named: 'content'),
+                    clientMessageId: any(named: 'clientMessageId'),
               ));
         },
       );
@@ -3192,6 +3242,7 @@ void main() {
           when(() => mockWebSocketService.sendMessage(
                 roomId: any(named: 'roomId'),
                 content: any(named: 'content'),
+                    clientMessageId: any(named: 'clientMessageId'),
               )).thenAnswer((_) {
             sendCallCount++;
             return sendCallCount >= 3;
@@ -3226,9 +3277,9 @@ void main() {
           // MessageRetryRequested: status changes to pending
           isA<ChatRoomState>()
               .having((s) => s.messages.first.sendStatus, 'sendStatus retry', MessageSendStatus.pending),
-          // Fire-and-forget retry succeeds → sent
+          // Fire-and-forget retry send() 성공 → echo 전이므로 sending (H2)
           isA<ChatRoomState>()
-              .having((s) => s.messages.first.sendStatus, 'sendStatus retry sent', MessageSendStatus.sent),
+              .having((s) => s.messages.first.sendStatus, 'sendStatus retry sending', MessageSendStatus.sending),
         ],
       );
 
@@ -3238,6 +3289,7 @@ void main() {
           when(() => mockWebSocketService.sendMessage(
                 roomId: any(named: 'roomId'),
                 content: any(named: 'content'),
+                    clientMessageId: any(named: 'clientMessageId'),
               )).thenReturn(false);
           when(() => mockWebSocketService.isConnected).thenReturn(false);
           when(() => mockWebSocketService.ensureConnected(
@@ -3300,6 +3352,7 @@ void main() {
           verifyNever(() => mockWebSocketService.sendMessage(
                 roomId: any(named: 'roomId'),
                 content: any(named: 'content'),
+                    clientMessageId: any(named: 'clientMessageId'),
               ));
         },
       );
@@ -3335,6 +3388,7 @@ void main() {
           when(() => mockWebSocketService.sendMessage(
                 roomId: any(named: 'roomId'),
                 content: any(named: 'content'),
+                    clientMessageId: any(named: 'clientMessageId'),
               )).thenReturn(false); // Message will fail
           when(() => mockWebSocketService.isConnected).thenReturn(false);
           when(() => mockWebSocketService.ensureConnected(
@@ -4249,9 +4303,9 @@ void main() {
               .having((s) => s.messages.length, 'messages.length', 1)
               .having((s) => s.messages.first.content, 'content', '답장 내용')
               .having((s) => s.messages.first.sendStatus, 'sendStatus', MessageSendStatus.pending),
-          // Second emit: message send completed (success)
+          // Second emit: send 완료 → echo 전이므로 sending (H2)
           isA<ChatRoomState>()
-              .having((s) => s.messages.first.sendStatus, 'sendStatus', MessageSendStatus.sent),
+              .having((s) => s.messages.first.sendStatus, 'sendStatus', MessageSendStatus.sending),
         ],
         verify: (_) {
           verify(() => mockChatRepository.replyToMessage(1, '답장 내용')).called(1);

--- a/test/blocs/message_cache_manager_test.dart
+++ b/test/blocs/message_cache_manager_test.dart
@@ -217,6 +217,100 @@ void main() {
               'and the bubble does not animate a second time');
     });
 
+    // ── H1: clientMessageId 기반 정확 매칭 ──────────────────────────────
+    test(
+        'echo with matching clientMessageId replaces the CORRECT pending '
+        'message even when two pending messages share identical content', () {
+      final now = DateTime.now();
+
+      // 동일 내용("ㅇㅇ")의 pending 메시지 2개 (실제 사용자가 연속 전송하는 상황).
+      final pending1 = Message(
+        id: -1,
+        chatRoomId: 1,
+        senderId: 42,
+        content: 'ㅇㅇ',
+        createdAt: now,
+        sendStatus: MessageSendStatus.sending,
+        localId: 'cmid-1',
+      );
+      final pending2 = Message(
+        id: -2,
+        chatRoomId: 1,
+        senderId: 42,
+        content: 'ㅇㅇ',
+        createdAt: now.add(const Duration(seconds: 1)),
+        sendStatus: MessageSendStatus.sending,
+        localId: 'cmid-2',
+      );
+      cacheManager.addPendingMessage(pending1);
+      cacheManager.addPendingMessage(pending2);
+
+      // 서버 echo가 두 번째 메시지(cmid-2)의 clientMessageId를 되돌려준다.
+      // convertToMessage가 이를 localId 슬롯에 담는다.
+      final echo = Message(
+        id: 500,
+        chatRoomId: 1,
+        senderId: 42,
+        content: 'ㅇㅇ',
+        // FIFO content 매칭이라면 가장 오래된 cmid-1을 골랐겠지만,
+        // clientMessageId 정확 매칭이면 cmid-2가 교체돼야 한다.
+        createdAt: now.add(const Duration(seconds: 3)),
+        localId: 'cmid-2',
+      );
+      final replaced =
+          cacheManager.replacePendingMessageWithReal('ㅇㅇ', echo);
+
+      expect(replaced, isTrue);
+      expect(cacheManager.messages.length, 2);
+
+      // cmid-2가 확정(sent, id=500)으로 교체됐는지 정확히 검증.
+      final confirmed = cacheManager.messages
+          .firstWhere((m) => m.localId == 'cmid-2');
+      expect(confirmed.id, 500);
+      expect(confirmed.sendStatus, MessageSendStatus.sent);
+
+      // cmid-1은 그대로 미확정(여전히 로컬 임시 ID)으로 남아 있어야 한다.
+      final stillPending = cacheManager.messages
+          .firstWhere((m) => m.localId == 'cmid-1');
+      expect(stillPending.id, -1);
+      expect(stillPending.isPending, isTrue);
+    });
+
+    test(
+        'falls back to content+window matching when echo lacks clientMessageId',
+        () {
+      final now = DateTime.now();
+      final pending = Message(
+        id: -1,
+        chatRoomId: 1,
+        senderId: 42,
+        content: 'Hello',
+        createdAt: now,
+        sendStatus: MessageSendStatus.sending,
+        localId: 'cmid-1',
+      );
+      cacheManager.addPendingMessage(pending);
+
+      // 백엔드 미지원: echo에 clientMessageId(localId)가 없다.
+      final echo = Message(
+        id: 600,
+        chatRoomId: 1,
+        senderId: 42,
+        content: 'Hello',
+        createdAt: now.add(const Duration(seconds: 2)),
+        // localId 없음 → fallback 경로
+      );
+      final replaced =
+          cacheManager.replacePendingMessageWithReal('Hello', echo);
+
+      expect(replaced, isTrue, reason: 'fallback content match should succeed');
+      final confirmed = cacheManager.messages.first;
+      expect(confirmed.id, 600);
+      expect(confirmed.sendStatus, MessageSendStatus.sent);
+      // fallback이어도 로컬 localId는 보존된다.
+      expect(confirmed.localId, 'cmid-1');
+    });
+
     test('addMessage adds new message at the beginning', () async {
       final msg1 = Message(
         id: 1,

--- a/test/core/auth_interceptor_test.dart
+++ b/test/core/auth_interceptor_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:dio/dio.dart';
 import 'package:co_talk_flutter/core/network/auth_interceptor.dart';
+import 'package:co_talk_flutter/core/network/certificate_pinning_interceptor.dart';
 import 'package:co_talk_flutter/data/datasources/local/auth_local_datasource.dart';
 
 class MockAuthLocalDataSource extends Mock implements AuthLocalDataSource {}
@@ -133,7 +134,8 @@ void main() {
 
   setUp(() {
     mockLocalDataSource = MockAuthLocalDataSource();
-    interceptor = AuthInterceptor(mockLocalDataSource);
+    interceptor =
+        AuthInterceptor(mockLocalDataSource, const CertificatePinningService());
   });
 
   group('AuthInterceptor', () {

--- a/test/core/dio_client_test.dart
+++ b/test/core/dio_client_test.dart
@@ -15,13 +15,14 @@ void main() {
   late DioClient dioClient;
   late MockAuthLocalDataSource mockAuthLocalDataSource;
   late AuthInterceptor authInterceptor;
-  late CertificatePinningInterceptor certificatePinningInterceptor;
+  late CertificatePinningService certificatePinningService;
 
   setUp(() {
     mockAuthLocalDataSource = MockAuthLocalDataSource();
-    authInterceptor = AuthInterceptor(mockAuthLocalDataSource);
-    certificatePinningInterceptor = CertificatePinningInterceptor();
-    dioClient = DioClient(authInterceptor, certificatePinningInterceptor);
+    certificatePinningService = const CertificatePinningService();
+    authInterceptor =
+        AuthInterceptor(mockAuthLocalDataSource, certificatePinningService);
+    dioClient = DioClient(authInterceptor, certificatePinningService);
   });
 
   group('DioClient', () {

--- a/test/core/network/certificate_pinning_test.dart
+++ b/test/core/network/certificate_pinning_test.dart
@@ -1,102 +1,120 @@
+import 'dart:convert';
+
+import 'package:crypto/crypto.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:dio/dio.dart';
 import 'package:co_talk_flutter/core/network/certificate_pinning_interceptor.dart';
 import 'package:co_talk_flutter/core/config/security_config.dart';
 
 void main() {
   group('Certificate Pinning', () {
     group('SecurityConfig', () {
-      test('should expose certificate pinning enabled flag', () {
+      test('exposes certificate pinning enabled flag', () {
         expect(SecurityConfig.certificatePinningEnabled, isA<bool>());
       });
 
-      test('should expose pinned certificates list', () {
+      test('exposes pinned certificates list', () {
         expect(SecurityConfig.pinnedCertificates, isA<List<String>>());
       });
 
-      test('should have at least one pinned certificate when enabled', () {
-        if (SecurityConfig.certificatePinningEnabled) {
-          expect(SecurityConfig.pinnedCertificates, isNotEmpty);
-        }
-      });
-
-      test('pinned certificates should be valid SHA-256 hashes', () {
-        for (final cert in SecurityConfig.pinnedCertificates) {
+      test('pinned certificates are valid SHA-256 hex strings', () {
+        for (final pin in SecurityConfig.pinnedCertificates) {
           // SHA-256 hash is 64 hex characters
-          expect(cert.length, equals(64));
-          expect(cert, matches(RegExp(r'^[a-fA-F0-9]{64}$')));
+          expect(pin.length, equals(64));
+          expect(pin, matches(RegExp(r'^[a-fA-F0-9]{64}$')));
+        }
+      });
+
+      test('hasRealPin is false while only the placeholder pin is configured', () {
+        // The placeholder (all-zeros) pin must NOT count as a real pin.
+        expect(SecurityConfig.hasRealPin, isFalse);
+      });
+
+      test(
+        'isProductionReady is false when pinning is enabled but no real pin set',
+        () {
+          // 거짓 production-ready 신호 제거 검증:
+          // - 실제(비-placeholder) 핀이 없으면 production-ready가 아니다.
+          // - certificatePinningEnabled가 true가 되려면 hasRealPin도 true여야
+          //   production-ready가 된다 (둘 다 만족해야 함).
+          if (SecurityConfig.certificatePinningEnabled) {
+            // 프로덕션 모드에서 실제 핀이 없으면 false.
+            expect(SecurityConfig.isProductionReady, SecurityConfig.hasRealPin);
+          } else {
+            // 개발/디버그(피닝 비활성): 의도적으로 끈 상태이므로 ok(true).
+            expect(SecurityConfig.isProductionReady, isTrue);
+          }
+        },
+      );
+
+      test('isPinningActive requires both enabled AND a real pin', () {
+        expect(
+          SecurityConfig.isPinningActive,
+          SecurityConfig.certificatePinningEnabled && SecurityConfig.hasRealPin,
+        );
+      });
+
+      test('productionWarning warns when not production-ready', () {
+        if (!SecurityConfig.isProductionReady) {
+          expect(
+            SecurityConfig.productionWarning,
+            contains('placeholder certificates'),
+          );
+        } else {
+          expect(SecurityConfig.productionWarning, contains('production-ready'));
         }
       });
     });
 
-    group('CertificatePinningInterceptor', () {
-      late CertificatePinningInterceptor interceptor;
+    group('CertificatePinningService.sha256OfDer', () {
+      test('computes a real SHA-256 (not raw hex of the bytes)', () {
+        final der = utf8.encode('certificate-der-bytes');
+        final expected = sha256.convert(der).toString();
 
-      setUp(() {
-        interceptor = CertificatePinningInterceptor();
+        final actual = CertificatePinningService.sha256OfDer(der);
+
+        expect(actual, equals(expected));
+        expect(actual.length, equals(64));
+        // Regression guard: old impl hex-encoded the raw bytes (length 2*N),
+        // which for this input would NOT be 64 chars.
+        final rawHex =
+            der.map((b) => b.toRadixString(16).padLeft(2, '0')).join();
+        expect(actual, isNot(equals(rawHex)));
       });
 
-      test('should be created successfully', () {
-        expect(interceptor, isA<Interceptor>());
-      });
-
-      test('should validate certificate when pinning is enabled', () {
-        // This test verifies the interceptor has validation logic
-        expect(interceptor, isNotNull);
-      });
-
-      test('should have error handler for certificate validation failures', () {
-        // This will be validated during integration testing
-        // For now, we just verify the interceptor exists
-        expect(interceptor, isA<CertificatePinningInterceptor>());
-      });
-    });
-
-    group('Certificate Validation Logic', () {
-      test('should reject connection with mismatched certificate', () {
-        // Mock scenario: server certificate doesn't match pinned certificate
-        final mismatchedHash = 'abcd' * 16; // 64 char hex string
-        final pinnedHash = '1234' * 16; // 64 char hex string
-
-        expect(mismatchedHash, isNot(equals(pinnedHash)));
-        expect(mismatchedHash.length, equals(64));
-      });
-
-      test('should accept connection with matching certificate', () {
-        // Mock scenario: server certificate matches pinned certificate
-        final serverHash = '1234' * 16;
-        final pinnedHash = '1234' * 16;
-
-        expect(serverHash, equals(pinnedHash));
+      test('is deterministic and lowercase hex', () {
+        final der = [1, 2, 3, 4, 5];
+        final a = CertificatePinningService.sha256OfDer(der);
+        final b = CertificatePinningService.sha256OfDer(der);
+        expect(a, equals(b));
+        expect(a, equals(a.toLowerCase()));
       });
     });
 
-    group('Environment-based Configuration', () {
-      test('certificate pinning should be configurable', () {
-        // In development, pinning might be disabled
-        // In production, pinning should be enabled
-        expect(SecurityConfig.certificatePinningEnabled, isA<bool>());
+    group('pin comparison', () {
+      test('matching fingerprint equals the computed SHA-256 pin', () {
+        final der = utf8.encode('server-cert');
+        final pin = CertificatePinningService.sha256OfDer(der);
+        // A genuine pin compares equal (case-insensitive) to the cert hash.
+        expect(pin.toLowerCase(), equals(pin.toLowerCase()));
       });
 
-      test('should support multiple pinned certificates for rotation', () {
-        // Allow multiple certificates to support certificate rotation
-        expect(SecurityConfig.pinnedCertificates, isA<List<String>>());
+      test('a different certificate yields a different pin', () {
+        final pinA = CertificatePinningService.sha256OfDer(utf8.encode('A'));
+        final pinB = CertificatePinningService.sha256OfDer(utf8.encode('B'));
+        expect(pinA, isNot(equals(pinB)));
       });
     });
 
-    group('Error Handling', () {
-      test('should provide clear error message for certificate mismatch', () {
-        final expectedErrorMessage =
-            'Certificate verification failed: Server certificate does not match pinned certificates';
-        expect(expectedErrorMessage, contains('Certificate verification failed'));
-        expect(expectedErrorMessage, contains('pinned certificates'));
+    group('CertificatePinningService', () {
+      test('is constructible', () {
+        expect(const CertificatePinningService(), isA<CertificatePinningService>());
       });
 
-      test('should provide clear error message when no certificates configured', () {
-        final expectedErrorMessage =
-            'Certificate pinning is enabled but no certificates are configured';
-        expect(expectedErrorMessage, contains('Certificate pinning is enabled'));
-        expect(expectedErrorMessage, contains('no certificates'));
+      test('createPinnedHttpClient returns a client', () {
+        final service = const CertificatePinningService();
+        final client = service.createPinnedHttpClient();
+        expect(client, isNotNull);
+        client.close(force: true);
       });
     });
   });


### PR DESCRIPTION
## 개요
Flutter 클라이언트의 보안/정확성 결함 3건을 수정합니다.

## C1 (CRITICAL) — 인증서 피닝 실제 동작화 + 가짜 production-ready 제거
기존 피닝은 보안상 무의미했습니다:
- `badCertificateCallback`을 가진 `HttpClient`가 Dio adapter에 연결되지 않고 plain Interceptor로만 등록 → 콜백 미호출
- `_calculateSha256`가 SHA-256이 아니라 DER 원본 바이트의 hex 인코딩
- 핀이 all-zeros placeholder인데 `isProductionReady`가 피닝 비활성 시 `true` 반환 → 보호 0인데 production-ready 통과

수정 (functional-pinning 선택):
- `CertificatePinningService`로 전환, `IOHttpClientAdapter(createHttpClient: ...)`로 `DioClient` + 토큰 갱신 `_refreshDio` 양쪽에 연결
- `crypto`로 인증서 DER의 SHA-256(hex)를 올바르게 계산, 핀 다중 등록(로테이션) 지원
- `isProductionReady`는 (피닝 활성 AND 실제 핀 존재)일 때만 `true`
- 참고: Dart `X509Certificate`가 SPKI를 직접 노출하지 않아 인증서 전체 DER SHA-256으로 비교

## H1 (HIGH) — 낙관적 전송 중복제거를 clientMessageId 기반으로
- STOMP send body에 `clientMessageId`(=localId) 포함
- echo의 `clientMessageId`를 파싱해 `Message.localId`로 매핑
- `replacePendingMessageWithReal`: clientMessageId 정확 매칭 우선, 없으면 기존 content+window fallback (무회귀)

## H2 (HIGH) — sending/sent 상태 분리
- `MessageSendStatus.sending` 추가. `send()` 완료 시 `sending`, 서버 echo 수신 시에만 `sent`로 승격
- 15초 pending-timeout 체커가 실패 백스톱 유지, UI는 `sending`을 로딩 인디케이터로 표시

## ⚠️ 백엔드 의존성
정확한 H1 매칭을 위해 **백엔드가 broadcast/echo 메시지에 `clientMessageId`를 그대로 echo**해야 합니다 (별도 백엔드 PR 예정). 그 전까지는 content+window fallback으로 동작합니다.

## 검증
- `flutter analyze`: **No issues found**
- `flutter test`: **All tests passed** (신규 C1 SHA-256/핀/production-ready, H1 동일내용 다중 pending 정확 매칭+fallback, H2 sending→echo→sent 테스트 포함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)