### PR TITLE
refactor: Flutter god-file 분할 + 라이프사이클/FCM/WS 정확성 정비 (M2~M4, L1~L4)

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -108,6 +108,18 @@ class CoTalkApp extends StatelessWidget {
   }
 }
 
+/// 앱 전역(global) 라이프사이클 옵저버.
+///
+/// 책임 경계(M2): 이 옵저버는 **앱 전역 보안 잠금(AppLockCubit)** 만 담당한다.
+/// 채팅 presence(active/inactive)와 WebSocket 연결 관리는 의도적으로 여기서
+/// 다루지 않는다 — presence는 본질적으로 "특정 방을 보고 있는가"라는 per-room
+/// 상태이고(presence_manager: sendPresenceActive/Inactive(roomId)), 그 책임은
+/// 방이 열려 있는 동안에만 존재하는 chat_room_page의 WidgetsBindingObserver가
+/// 가진다(1.5s 디바운스, iOS inactive-vs-paused 구분 포함).
+///
+/// 따라서 채팅 "목록"(방 밖)에서 백그라운드로 가도 누락되는 presence 의무는
+/// 없다: 목록에서는 활성(active)으로 표시된 방이 애초에 없으므로 해제할 상태가
+/// 없고, 모든 방의 푸시는 정상 수신된다. 두 옵저버의 역할은 겹치지 않는다.
 class _AppLifecycleHandler extends StatefulWidget {
   final Widget child;
   const _AppLifecycleHandler({required this.child});

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -32,6 +32,12 @@ class CoTalkApp extends StatelessWidget {
             authInterceptor.setAuthBloc(authBloc);
             authInterceptor.setWebSocketService(webSocketService);
 
+            // WebSocket 재연결 시 토큰 갱신을 AuthInterceptor의 single-flight
+            // refresh로 위임 (refresh authority 단일화 → rotation race 제거).
+            webSocketService.setTokenRefreshDelegate(
+              authInterceptor.refreshTokenForReconnect,
+            );
+
             return authBloc;
           },
         ),

--- a/lib/core/network/auth_interceptor.dart
+++ b/lib/core/network/auth_interceptor.dart
@@ -169,6 +169,21 @@ class AuthInterceptor extends QueuedInterceptor {
     handler.next(err);
   }
 
+  /// WebSocket 재연결 등 인터셉터 외부에서 토큰 갱신이 필요할 때 호출한다.
+  ///
+  /// HTTP 401 처리와 동일한 single-flight refresh([_ensureRefreshed])를 공유하므로
+  /// refresh authority가 하나로 유지된다. 이전에 WebSocket이 별도 Dio로 refresh를
+  /// 수행하면서 발생하던 refresh-token rotation race(옛 토큰 무효화 → 강제 로그아웃)를
+  /// 방지한다. best-effort: 성공/실패와 무관하게 예외를 던지지 않는다.
+  Future<void> refreshTokenForReconnect() async {
+    if (_isDisposed) return;
+    try {
+      await _ensureRefreshed();
+    } catch (_) {
+      // best-effort: 재연결 흐름을 막지 않도록 실패를 흡수한다.
+    }
+  }
+
   /// Single-flight refresh.
   ///
   /// 진행 중인 refresh가 있으면 그 Future를 그대로 반환하고,

--- a/lib/core/network/websocket/websocket_connection_manager.dart
+++ b/lib/core/network/websocket/websocket_connection_manager.dart
@@ -211,24 +211,56 @@ class WebSocketConnectionManager {
 
   void _onStompError(StompFrame frame) {
     if (kDebugMode) {
-      debugPrint('[WebSocket] STOMP Error: ${frame.body}');
+      debugPrint('[WebSocket] STOMP Error: headers=${frame.headers}, body=${frame.body}');
     }
 
-    final body = frame.body ?? '';
-    final isAuthError = body.contains('401') ||
-                        body.toLowerCase().contains('unauthorized') ||
-                        body.toLowerCase().contains('authentication') ||
-                        body.toLowerCase().contains('access denied');
+    final isAuthError = _isAuthError(frame);
 
     _updateConnectionState(WebSocketConnectionState.disconnected);
     onDisconnected?.call();
 
     if (isAuthError) {
-      if (kDebugMode) debugPrint('[WebSocket] Auth error detected: $body');
+      if (kDebugMode) debugPrint('[WebSocket] Auth error detected: ${frame.body}');
       // Mark that a token refresh is needed before the next reconnection.
       _needsTokenRefresh = true;
     }
     _attemptReconnect();
+  }
+
+  /// STOMP ERROR 프레임이 인증(토큰 만료/거부) 오류인지 판정한다.
+  ///
+  /// 인증 오류 감지의 단일 진입점(centralized): 분산된 문자열 매칭을 한곳에 모아
+  /// 재연결 전 토큰 갱신 여부를 결정한다.
+  ///
+  /// 우선순위:
+  /// 1. 구조적 신호 — STOMP ERROR 프레임의 헤더. STOMP 명세상 ERROR 프레임은
+  ///    사람이 읽을 수 있는 `message` 헤더를 가질 수 있고, 서버가 status/code
+  ///    헤더로 HTTP 상태를 전달하는 경우도 있다. 헤더가 401/403/UNAUTHORIZED
+  ///    계열이면 우선 신뢰한다(본문 문자열보다 견고).
+  /// 2. fallback — 서버가 구조화된 헤더 없이 텍스트 본문만 보낼 때를 대비해
+  ///    본문/메시지 헤더 텍스트를 robust하게 매칭한다.
+  static bool _isAuthError(StompFrame frame) {
+    final headers = frame.headers;
+
+    // 1. 구조적 신호: status/code 류 헤더의 HTTP 상태 코드.
+    for (final key in const ['status', 'status-code', 'code']) {
+      final value = headers[key];
+      if (value != null) {
+        final parsed = int.tryParse(value.trim());
+        if (parsed == 401 || parsed == 403) return true;
+      }
+    }
+
+    // 2. 텍스트 매칭 fallback: `message` 헤더 + 본문을 합쳐 한 번에 검사한다.
+    final haystack =
+        '${headers['message'] ?? ''} ${frame.body ?? ''}'.toLowerCase();
+    if (haystack.isEmpty) return false;
+    return haystack.contains('401') ||
+        haystack.contains('403') ||
+        haystack.contains('unauthorized') ||
+        haystack.contains('authentication') ||
+        haystack.contains('access denied') ||
+        haystack.contains('forbidden');
   }
 
   void _onWebSocketError(dynamic error) {

--- a/lib/core/network/websocket_service.dart
+++ b/lib/core/network/websocket_service.dart
@@ -45,6 +45,12 @@ class WebSocketService {
   final WebSocketMessageSender _messageSender;
   final EventDedupeCache _dedupeCache;
 
+  // WebSocket 재연결 시 토큰 갱신을 위임할 single-flight refresh 콜백.
+  // AuthInterceptor.refreshTokenForReconnect를 app.dart에서 주입한다.
+  // 콜백(typedef)으로 두어 auth_interceptor ↔ websocket_service 임포트 순환을
+  // 피한다 (AuthInterceptor가 이미 WebSocketService를 참조하므로).
+  Future<void> Function()? _externalTokenRefresh;
+
   // Subscription restore timer
   Timer? _subscriptionRestoreTimer;
 
@@ -83,6 +89,12 @@ class WebSocketService {
     _connectionManager.onConnected = _onConnected;
     _connectionManager.onDisconnected = _onDisconnected;
     _connectionManager.onTokenRefreshNeeded = _refreshTokenForReconnect;
+  }
+
+  /// 재연결 시 토큰 갱신을 위임할 single-flight refresh 콜백을 주입한다.
+  /// (순환 참조 방지를 위해 app.dart에서 AuthInterceptor의 메서드를 늦게 설정)
+  void setTokenRefreshDelegate(Future<void> Function() refresh) {
+    _externalTokenRefresh = refresh;
   }
 
   // ============================================================
@@ -573,7 +585,31 @@ class WebSocketService {
 
   /// Attempts to refresh the access token when WebSocket auth error occurs.
   /// Called by [WebSocketConnectionManager] before reconnection.
+  ///
+  /// 토큰 갱신은 AuthInterceptor의 single-flight refresh([_externalTokenRefresh])로
+  /// 위임한다. refresh authority를 하나로 통합해, WebSocket이 별도 Dio로 refresh를
+  /// 수행하며 HTTP 인터셉터의 single-flight와 경쟁하던 race(refresh-token rotation으로
+  /// 한쪽 토큰이 무효화 → 강제 로그아웃)를 제거한다. best-effort.
+  ///
+  /// delegate가 아직 주입되지 않은 경우(예: 위젯 외부 테스트)에는 기존처럼 일회용
+  /// Dio로 직접 refresh하는 fallback을 유지해 동작 변화를 막는다.
   Future<void> _refreshTokenForReconnect() async {
+    final delegate = _externalTokenRefresh;
+    if (delegate != null) {
+      try {
+        await delegate();
+        if (kDebugMode) {
+          debugPrint('[WebSocket] Token refresh delegated to single-flight refresh');
+        }
+      } catch (e) {
+        if (kDebugMode) {
+          debugPrint('[WebSocket] Delegated token refresh failed: $e');
+        }
+      }
+      return;
+    }
+
+    // Fallback (delegate 미주입): 기존 동작 보존을 위한 일회용 Dio refresh.
     Dio? dio;
     try {
       final refreshToken = await _authLocalDataSource.getRefreshToken();

--- a/lib/core/services/desktop_notification_bridge.dart
+++ b/lib/core/services/desktop_notification_bridge.dart
@@ -113,7 +113,12 @@ class DesktopNotificationBridge {
       previewMode = settings.notificationPreviewMode;
       soundEnabled = settings.soundEnabled;
       vibrationEnabled = settings.vibrationEnabled;
-    } catch (_) {}
+    } catch (e) {
+      // best-effort: 설정 조회 실패 시 기본값 유지하되 debug에서는 가시화.
+      if (kDebugMode) {
+        debugPrint('[DesktopNotificationBridge] Failed to load notification settings, using defaults: $e');
+      }
+    }
 
     // Apply preview mode
     String title;

--- a/lib/core/services/fcm_service.dart
+++ b/lib/core/services/fcm_service.dart
@@ -5,6 +5,7 @@ import 'dart:io';
 import 'package:firebase_messaging/firebase_messaging.dart' hide NotificationSettings;
 import 'package:firebase_messaging/firebase_messaging.dart' as fcm show NotificationSettings;
 import 'package:flutter/foundation.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:injectable/injectable.dart';
 
 import '../../domain/entities/notification_settings.dart';
@@ -311,14 +312,111 @@ class FcmServiceImpl implements FcmService {
 /// 앱이 백그라운드 또는 종료 상태일 때 FCM 메시지를 처리합니다.
 /// main() 함수에서 FirebaseMessaging.onBackgroundMessage로 등록해야 합니다.
 ///
-/// 중요: 이 함수는 top-level 함수여야 하며, 클래스 인스턴스에 의존하면 안 됩니다.
+/// 중요: 이 함수는 top-level 함수여야 하며, 별도 isolate에서 실행되므로
+/// 앱의 DI(NotificationService 등) 인스턴스에 의존하면 안 됩니다.
+///
+/// 동작:
+/// - notification 블록이 있는 푸시: OS/FCM이 트레이 알림을 자동 표시하므로
+///   여기서는 아무것도 하지 않는다(중복 알림 방지). 포그라운드 억제 경로
+///   (_handleForegroundMessageAsync)와도 겹치지 않는다 — 그쪽은 onMessage(포그라운드)
+///   전용이고 이 핸들러는 백그라운드/종료 상태 전용이다.
+/// - data-only 푸시(notification == null): 시스템이 자동 표시하지 않으므로
+///   killed/background 사용자에게 알림이 누락된다. 이 경우에만 별도 isolate에서
+///   가벼운 FlutterLocalNotificationsPlugin을 생성해 로컬 알림을 직접 표시한다.
 @pragma('vm:entry-point')
 Future<void> firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   if (kDebugMode) {
-    debugPrint('[FCM] Background message received: ${message.messageId}');
+    debugPrint('[FCM] Background message received: ${message.messageId}, '
+        'hasNotification=${message.notification != null}, data=${message.data}');
   }
-  // 백그라운드 메시지는 시스템이 자동으로 알림을 표시합니다.
-  // 추가적인 데이터 처리가 필요한 경우 여기에 로직을 추가합니다.
+
+  // notification 블록이 있으면 OS/FCM이 트레이 알림을 표시한다 → 중복 방지를 위해 종료.
+  if (message.notification != null) {
+    return;
+  }
+
+  // data-only 푸시: 표시할 내용이 없으면 종료.
+  final data = message.data;
+  if (data.isEmpty) {
+    if (kDebugMode) {
+      debugPrint('[FCM] Background data-only push with empty data, nothing to show');
+    }
+    return;
+  }
+
+  await _showDataOnlyBackgroundNotification(data);
+}
+
+/// data-only 백그라운드 푸시를 로컬 알림으로 표시한다.
+///
+/// 별도 isolate에서 호출되므로 새 플러그인 인스턴스를 만들어 초기화한다.
+/// Android 채널 id는 NotificationService와 동일한 'chat_messages'를 사용해
+/// 포그라운드/데스크톱 경로와 채널 설정을 일치시킨다.
+Future<void> _showDataOnlyBackgroundNotification(
+  Map<String, dynamic> data,
+) async {
+  try {
+    final plugin = FlutterLocalNotificationsPlugin();
+
+    const androidInit = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const darwinInit = DarwinInitializationSettings();
+    const initSettings = InitializationSettings(
+      android: androidInit,
+      iOS: darwinInit,
+      macOS: darwinInit,
+    );
+    await plugin.initialize(initSettings);
+
+    // 서버 data 페이로드에서 제목/본문/네비게이션 정보를 추출한다.
+    // 서버 키 변형을 흡수하기 위해 몇 가지 후보 키를 순서대로 확인한다.
+    final title = (data['title'] ?? data['senderNickname'] ?? '새 메시지').toString();
+    final body = (data['body'] ?? data['message'] ?? data['lastMessage'] ?? '새 메시지가 도착했습니다').toString();
+
+    // 알림 탭 시 채팅방으로 이동할 수 있도록 payload 형식: 'chatRoom:roomId'
+    String? payload;
+    final chatRoomId = data['chatRoomId'];
+    if (chatRoomId != null) {
+      payload = 'chatRoom:$chatRoomId';
+    } else {
+      payload = jsonEncode(data);
+    }
+
+    const androidDetails = AndroidNotificationDetails(
+      'chat_messages', // NotificationService._channelId 와 동일하게 유지
+      'Chat Messages',
+      channelDescription: 'Notifications for new chat messages',
+      icon: '@mipmap/ic_launcher',
+      importance: Importance.high,
+      priority: Priority.high,
+      autoCancel: true,
+    );
+    const darwinDetails = DarwinNotificationDetails(
+      presentAlert: true,
+      presentBadge: true,
+      presentSound: true,
+    );
+    const notificationDetails = NotificationDetails(
+      android: androidDetails,
+      iOS: darwinDetails,
+      macOS: darwinDetails,
+    );
+
+    // 백그라운드 isolate에는 카운터 상태가 없으므로 시간 기반 id를 사용한다.
+    final notificationId =
+        DateTime.now().millisecondsSinceEpoch.remainder(2147483647);
+
+    await plugin.show(
+      notificationId,
+      title,
+      body,
+      notificationDetails,
+      payload: payload,
+    );
+  } catch (e) {
+    if (kDebugMode) {
+      debugPrint('[FCM] Failed to show data-only background notification: $e');
+    }
+  }
 }
 
 // 환경 상수

--- a/lib/core/services/fcm_service.dart
+++ b/lib/core/services/fcm_service.dart
@@ -50,21 +50,21 @@ class NoOpFcmService implements FcmService {
   void dispose() {}
 }
 
-/// FCM 푸시 알림 서비스 구현 (현재 Android 전용)
+/// FCM 푸시 알림 서비스 구현 (Android 및 iOS 지원)
 ///
 /// Firebase Cloud Messaging을 통한 푸시 알림을 처리합니다.
 /// - FCM 토큰 발급 및 갱신
 /// - 포그라운드 메시지 처리 (로컬 알림으로 표시)
 /// - 백그라운드 메시지 핸들러 설정
 ///
-/// TODO: iOS 푸시 알림 활성화 필요
-/// iOS 설정 필요사항:
-/// 1. Apple Developer Program 유료 가입 ($99/년)
-/// 2. Xcode > Signing & Capabilities > Push Notifications 추가
-/// 3. Xcode > Signing & Capabilities > Background Modes > Remote notifications 체크
-/// 4. Apple Developer > Keys에서 APNs 키 발급 (.p8 파일)
-/// 5. Firebase Console > 프로젝트 설정 > 클라우드 메시징에 APNs 키 업로드
-/// 6. main.dart와 이 파일에서 Platform.isIOS 조건 추가
+/// iOS 푸시는 코드/네이티브 양쪽에서 활성화되어 있습니다:
+/// - main.dart / di/injection.dart / auth_bloc.dart 의 Platform.isIOS 분기
+///   (iOS는 mobile 환경 → 이 FcmServiceImpl 사용, NoOp 아님)
+/// - ios/Runner/AppDelegate.swift: registerForRemoteNotifications() +
+///   Messaging.messaging().apnsToken 전달
+/// - ios/Runner/Runner.entitlements: aps-environment (production),
+///   RunnerDebug.entitlements: development
+/// - ios/Runner/Info.plist: UIBackgroundModes에 remote-notification
 @LazySingleton(as: FcmService, env: [_mobileEnv])
 class FcmServiceImpl implements FcmService {
   final FirebaseMessaging _messaging;

--- a/lib/core/services/fcm_service.dart
+++ b/lib/core/services/fcm_service.dart
@@ -220,7 +220,12 @@ class FcmServiceImpl implements FcmService {
       previewMode = settings.notificationPreviewMode;
       soundEnabled = settings.soundEnabled;
       vibrationEnabled = settings.vibrationEnabled;
-    } catch (_) {}
+    } catch (e) {
+      // best-effort: 설정 조회 실패 시 기본값 유지하되 debug에서는 가시화.
+      if (kDebugMode) {
+        debugPrint('[FcmService] Failed to load notification settings, using defaults: $e');
+      }
+    }
 
     String title;
     String body;

--- a/lib/core/services/notification_click_handler.dart
+++ b/lib/core/services/notification_click_handler.dart
@@ -100,7 +100,13 @@ class NotificationClickHandler {
         if (id is int) return id;
         if (id is String) return int.tryParse(id);
       }
-    } catch (_) {}
+    } catch (e) {
+      // best-effort: payload가 JSON이 아니거나 형식 불일치면 null 반환하되
+      // debug에서는 가시화.
+      if (kDebugMode) {
+        debugPrint('[NotificationClickHandler] Failed to parse chatRoomId from payload: $e');
+      }
+    }
     return null;
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -40,11 +40,10 @@ void main() async {
     await initializeDateFormatting('ko_KR', null);
 
     // Initialize Firebase (Android and iOS)
-    // iOS 설정 필요사항:
-    // 1. Apple Developer Program 유료 가입
-    // 2. Xcode에서 Push Notifications capability 추가
-    // 3. Xcode에서 Background Modes > Remote notifications 추가
-    // 4. APNs 인증 키 발급 후 Firebase Console에 업로드
+    // iOS 푸시는 이미 활성화되어 있다(Apple Developer 가입, Push Notifications
+    // capability, Background Modes > Remote notifications, APNs 키 업로드 완료).
+    // 네이티브 설정은 ios/Runner/AppDelegate.swift, Runner.entitlements,
+    // Info.plist(UIBackgroundModes: remote-notification) 참고.
     if (!kIsWeb && (Platform.isAndroid || Platform.isIOS)) {
       await Firebase.initializeApp();
 

--- a/lib/presentation/blocs/chat/chat_room_bloc.dart
+++ b/lib/presentation/blocs/chat/chat_room_bloc.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -35,6 +34,9 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
   late final PresenceManager _presenceManager;
   late final MessageCacheManager _cacheManager;
   late final MessageHandler _messageHandler;
+  late final ReactionHandler _reactionHandler;
+  // 읽음(read-receipt) unreadCount 계산 전담(순수 계산기, 부수효과 없음).
+  final ReadReceiptCalculator _readReceiptCalculator = const ReadReceiptCalculator();
 
   // State tracking
   bool _roomInitialized = false;
@@ -130,6 +132,7 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
       _webSocketService,
       _authLocalDataSource,
     );
+    _reactionHandler = ReactionHandler(_cacheManager, _webSocketService);
 
     // Register event handlers
     on<ChatRoomOpened>(_onOpened);
@@ -1126,38 +1129,27 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
     // 내가 읽은 이벤트는 무시
     if (event.userId == state.currentUserId) return;
 
+    final currentUserId = state.currentUserId!;
+
     // 중복 읽음 이벤트 방지: (userId, lastReadMessageId) 또는 (userId, lastReadAt) 조합으로 체크
-    final eventKey = '${event.userId}_${event.lastReadMessageId ?? event.lastReadAt?.millisecondsSinceEpoch ?? 'all'}';
+    final eventKey = _readReceiptCalculator.dedupKey(
+      userId: event.userId,
+      lastReadMessageId: event.lastReadMessageId,
+      lastReadAt: event.lastReadAt,
+    );
     if (state.processedReadEvents.contains(eventKey)) {
       _log('_onMessagesReadUpdated: Duplicate read event ignored: $eventKey');
       return;
     }
 
-    // 메시지 업데이트 함수
+    // 메시지 업데이트 함수 (순수 계산은 ReadReceiptCalculator에 위임)
     Message updateMessageReadCount(Message message) {
-      // 내가 보낸 메시지만 업데이트
-      if (message.senderId != state.currentUserId) return message;
-      // 이미 0이면 더 감소하지 않음
-      if (message.unreadCount <= 0) return message;
-
-      // 1. lastReadMessageId가 있으면 해당 ID 이하 메시지만 업데이트
-      if (event.lastReadMessageId != null) {
-        if (message.id <= event.lastReadMessageId!) {
-          return message.copyWith(unreadCount: message.unreadCount - 1);
-        }
-        return message;
-      }
-
-      // 2. lastReadMessageId가 없고 lastReadAt이 있으면 해당 시간 이전 메시지만 업데이트
-      if (event.lastReadAt != null) {
-        if (!message.createdAt.isAfter(event.lastReadAt!)) {
-          return message.copyWith(unreadCount: message.unreadCount - 1);
-        }
-        return message;
-      }
-
-      // 3. 둘 다 없으면 모든 메시지를 읽음 처리
-      return message.copyWith(unreadCount: message.unreadCount - 1);
+      return _readReceiptCalculator.applyToMessage(
+        message,
+        currentUserId: currentUserId,
+        lastReadMessageId: event.lastReadMessageId,
+        lastReadAt: event.lastReadAt,
+      );
     }
 
     // Use state.messages directly to handle seed state in tests
@@ -1181,16 +1173,11 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
     // Also update cache manager for consistency
     _cacheManager.updateMessages(updateMessageReadCount);
 
-    // 처리된 이벤트 기록 (LinkedHashSet을 사용하여 삽입 순서 보장)
-    var newProcessedEvents = LinkedHashSet<String>.from(state.processedReadEvents)..add(eventKey);
-    // Cap the set to prevent unbounded growth
-    if (newProcessedEvents.length > 500) {
-      // Keep only the most recent entries by taking the last 250
-      final eventsList = newProcessedEvents.toList();
-      newProcessedEvents = LinkedHashSet<String>.from(
-        eventsList.sublist(eventsList.length - 250),
-      );
-    }
+    // 처리된 이벤트 기록 (삽입 순서 보장 + 무한 증가 방지 캡은 calculator에 위임)
+    final newProcessedEvents = _readReceiptCalculator.appendProcessedEvent(
+      state.processedReadEvents,
+      eventKey,
+    );
 
     emit(state.copyWith(
       messages: updatedMessages,
@@ -1430,87 +1417,52 @@ class ChatRoomBloc extends Bloc<ChatRoomEvent, ChatRoomState> {
   // Reaction Handlers
   // ============================================================
 
-  /// 리액션 추가 요청 처리
+  /// 리액션 추가 요청 처리 (cache mutation/WS 전송은 ReactionHandler에 위임)
   void _onReactionAddRequested(
     ReactionAddRequested event,
     Emitter<ChatRoomState> emit,
   ) {
-    _log('_onReactionAddRequested: messageId=${event.messageId}, emoji=${event.emoji}');
-
-    // Sync cache manager with state if out of sync (for tests with seeded state)
-    if (_cacheManager.messages.isEmpty && state.messages.isNotEmpty) {
-      _cacheManager.syncMessages(state.messages);
-    }
-
-    // Optimistic UI update - add reaction immediately
-    final currentUserId = state.currentUserId;
-    if (currentUserId != null) {
-      final optimisticReaction = MessageReaction(
-        id: 0, // temporary ID, will be replaced by server echo
-        messageId: event.messageId,
-        userId: currentUserId,
-        emoji: event.emoji,
-      );
-      _cacheManager.addReaction(event.messageId, optimisticReaction);
-      emit(state.copyWith(messages: _cacheManager.messages));
-    }
-
-    _webSocketService.addReaction(
+    final updated = _reactionHandler.addRequested(
       messageId: event.messageId,
       emoji: event.emoji,
+      currentUserId: state.currentUserId,
+      stateMessages: state.messages,
     );
+    if (updated != null) {
+      emit(state.copyWith(messages: updated));
+    }
   }
 
-  /// 리액션 제거 요청 처리
+  /// 리액션 제거 요청 처리 (cache mutation/WS 전송은 ReactionHandler에 위임)
   void _onReactionRemoveRequested(
     ReactionRemoveRequested event,
     Emitter<ChatRoomState> emit,
   ) {
-    _log('_onReactionRemoveRequested: messageId=${event.messageId}, emoji=${event.emoji}');
-
-    // Sync cache manager with state if out of sync (for tests with seeded state)
-    if (_cacheManager.messages.isEmpty && state.messages.isNotEmpty) {
-      _cacheManager.syncMessages(state.messages);
-    }
-
-    // Optimistic UI update - remove reaction immediately
-    final currentUserId = state.currentUserId;
-    if (currentUserId != null) {
-      _cacheManager.removeReaction(event.messageId, currentUserId, event.emoji);
-      emit(state.copyWith(messages: _cacheManager.messages));
-    }
-
-    _webSocketService.removeReaction(
+    final updated = _reactionHandler.removeRequested(
       messageId: event.messageId,
       emoji: event.emoji,
+      currentUserId: state.currentUserId,
+      stateMessages: state.messages,
     );
+    if (updated != null) {
+      emit(state.copyWith(messages: updated));
+    }
   }
 
-  /// 리액션 이벤트 수신 처리 (WebSocket)
+  /// 리액션 이벤트 수신 처리 (WebSocket) — cache mutation은 ReactionHandler에 위임
   void _onReactionEventReceived(
     ReactionEventReceived event,
     Emitter<ChatRoomState> emit,
   ) {
-    _log('_onReactionEventReceived: messageId=${event.messageId}, userId=${event.userId}, emoji=${event.emoji}, isAdd=${event.isAdd}');
-
-    // Sync cache manager with state if out of sync (for tests with seeded state)
-    if (_cacheManager.messages.isEmpty && state.messages.isNotEmpty) {
-      _cacheManager.syncMessages(state.messages);
-    }
-
-    if (event.isAdd) {
-      final reaction = MessageReaction(
-        id: event.reactionId ?? 0,
-        messageId: event.messageId,
-        userId: event.userId,
-        userNickname: event.userNickname,
-        emoji: event.emoji,
-      );
-      _cacheManager.addReaction(event.messageId, reaction);
-    } else {
-      _cacheManager.removeReaction(event.messageId, event.userId, event.emoji);
-    }
-
-    emit(state.copyWith(messages: _cacheManager.messages));
+    final updated = _reactionHandler.eventReceived(
+      messageId: event.messageId,
+      userId: event.userId,
+      userNickname: event.userNickname,
+      emoji: event.emoji,
+      isAdd: event.isAdd,
+      reactionId: event.reactionId,
+      stateMessages: state.messages,
+    );
+    emit(state.copyWith(messages: updated));
   }
 }

--- a/lib/presentation/blocs/chat/managers/managers.dart
+++ b/lib/presentation/blocs/chat/managers/managers.dart
@@ -5,4 +5,6 @@
 export 'message_cache_manager.dart';
 export 'message_handler.dart';
 export 'presence_manager.dart';
+export 'reaction_handler.dart';
+export 'read_receipt_calculator.dart';
 export 'websocket_subscription_manager.dart';

--- a/lib/presentation/blocs/chat/managers/reaction_handler.dart
+++ b/lib/presentation/blocs/chat/managers/reaction_handler.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/foundation.dart';
+
+import '../../../../core/network/websocket_service.dart';
+import '../../../../domain/entities/message.dart';
+import 'message_cache_manager.dart';
+
+/// 리액션(이모지) 추가/제거/수신 처리를 담당하는 collaborator.
+///
+/// ChatRoomBloc의 세 reaction 핸들러에서 반복되던
+/// "cache 동기화 → optimistic mutation → WebSocket 전송" 흐름을 모았다.
+/// emit/state는 bloc이 그대로 보유하고, 이 핸들러는 캐시 변형과 WS 호출만
+/// 담당하며 갱신된 메시지 리스트를 돌려준다(동작 보존).
+class ReactionHandler {
+  final MessageCacheManager _cacheManager;
+  final WebSocketService _webSocketService;
+
+  ReactionHandler(this._cacheManager, this._webSocketService);
+
+  void _log(String message) {
+    if (kDebugMode) {
+      debugPrint('[ChatRoomBloc] $message');
+    }
+  }
+
+  /// seeded state(테스트 등)에서 cache가 비어있고 state에는 메시지가 있으면 동기화.
+  /// 원본 핸들러의 "Sync cache manager with state if out of sync" 가드와 동일.
+  void _syncCacheIfNeeded(List<Message> stateMessages) {
+    if (_cacheManager.messages.isEmpty && stateMessages.isNotEmpty) {
+      _cacheManager.syncMessages(stateMessages);
+    }
+  }
+
+  /// 리액션 추가 요청 처리(낙관적 갱신).
+  ///
+  /// [currentUserId]가 null이면 낙관적 갱신을 건너뛰지만, WebSocket 전송은
+  /// 원본과 동일하게 항상 수행한다. 낙관적 갱신이 일어나 emit이 필요하면 갱신된
+  /// 메시지 리스트를 반환하고, 아니면 null을 반환한다.
+  List<Message>? addRequested({
+    required int messageId,
+    required String emoji,
+    required int? currentUserId,
+    required List<Message> stateMessages,
+  }) {
+    _log('_onReactionAddRequested: messageId=$messageId, emoji=$emoji');
+    _syncCacheIfNeeded(stateMessages);
+
+    List<Message>? updated;
+    if (currentUserId != null) {
+      final optimisticReaction = MessageReaction(
+        id: 0, // temporary ID, will be replaced by server echo
+        messageId: messageId,
+        userId: currentUserId,
+        emoji: emoji,
+      );
+      _cacheManager.addReaction(messageId, optimisticReaction);
+      updated = _cacheManager.messages;
+    }
+
+    _webSocketService.addReaction(messageId: messageId, emoji: emoji);
+    return updated;
+  }
+
+  /// 리액션 제거 요청 처리(낙관적 갱신).
+  List<Message>? removeRequested({
+    required int messageId,
+    required String emoji,
+    required int? currentUserId,
+    required List<Message> stateMessages,
+  }) {
+    _log('_onReactionRemoveRequested: messageId=$messageId, emoji=$emoji');
+    _syncCacheIfNeeded(stateMessages);
+
+    List<Message>? updated;
+    if (currentUserId != null) {
+      _cacheManager.removeReaction(messageId, currentUserId, emoji);
+      updated = _cacheManager.messages;
+    }
+
+    _webSocketService.removeReaction(messageId: messageId, emoji: emoji);
+    return updated;
+  }
+
+  /// WebSocket으로 수신한 리액션 이벤트 처리. 항상 갱신된 메시지 리스트를 반환한다.
+  List<Message> eventReceived({
+    required int messageId,
+    required int userId,
+    String? userNickname,
+    required String emoji,
+    required bool isAdd,
+    int? reactionId,
+    required List<Message> stateMessages,
+  }) {
+    _log('_onReactionEventReceived: messageId=$messageId, userId=$userId, emoji=$emoji, isAdd=$isAdd');
+    _syncCacheIfNeeded(stateMessages);
+
+    if (isAdd) {
+      final reaction = MessageReaction(
+        id: reactionId ?? 0,
+        messageId: messageId,
+        userId: userId,
+        userNickname: userNickname,
+        emoji: emoji,
+      );
+      _cacheManager.addReaction(messageId, reaction);
+    } else {
+      _cacheManager.removeReaction(messageId, userId, emoji);
+    }
+
+    return _cacheManager.messages;
+  }
+}

--- a/lib/presentation/blocs/chat/managers/read_receipt_calculator.dart
+++ b/lib/presentation/blocs/chat/managers/read_receipt_calculator.dart
@@ -1,0 +1,81 @@
+import 'dart:collection';
+
+import '../../../../domain/entities/message.dart';
+
+/// 읽음(read-receipt) 이벤트를 메시지 unreadCount에 반영하는 순수 계산기.
+///
+/// ChatRoomBloc._onMessagesReadUpdated에서 emit/state/manager와 얽혀 있던
+/// "계산" 부분만 추출했다. 부수효과(emit, 네트워크, manager 호출)는 전혀 없고,
+/// 입력 → 출력만 계산하므로 동작 보존(behavior-preserving) 검증이 쉽다.
+class ReadReceiptCalculator {
+  const ReadReceiptCalculator();
+
+  /// 처리된 read 이벤트 중복 판별용 키.
+  ///
+  /// (userId, lastReadMessageId) 또는 (userId, lastReadAt) 조합으로 식별하며,
+  /// 둘 다 없으면 'all'로 폴백한다.
+  String dedupKey({
+    required int userId,
+    int? lastReadMessageId,
+    DateTime? lastReadAt,
+  }) {
+    final suffix =
+        lastReadMessageId ?? lastReadAt?.millisecondsSinceEpoch ?? 'all';
+    return '${userId}_$suffix';
+  }
+
+  /// 단일 메시지의 unreadCount를 read 이벤트에 따라 갱신한다.
+  ///
+  /// 규칙(원본 _onMessagesReadUpdated.updateMessageReadCount와 동일):
+  /// - 내가([currentUserId]) 보낸 메시지만 대상.
+  /// - 이미 0 이하이면 그대로 둔다.
+  /// - lastReadMessageId가 있으면 해당 ID 이하 메시지만 -1.
+  /// - 없고 lastReadAt이 있으면 그 시각 이전(또는 같음) 메시지만 -1.
+  /// - 둘 다 없으면 모든 대상 메시지 -1.
+  Message applyToMessage(
+    Message message, {
+    required int currentUserId,
+    int? lastReadMessageId,
+    DateTime? lastReadAt,
+  }) {
+    // 내가 보낸 메시지만 업데이트
+    if (message.senderId != currentUserId) return message;
+    // 이미 0이면 더 감소하지 않음
+    if (message.unreadCount <= 0) return message;
+
+    // 1. lastReadMessageId가 있으면 해당 ID 이하 메시지만 업데이트
+    if (lastReadMessageId != null) {
+      if (message.id <= lastReadMessageId) {
+        return message.copyWith(unreadCount: message.unreadCount - 1);
+      }
+      return message;
+    }
+
+    // 2. lastReadMessageId가 없고 lastReadAt이 있으면 해당 시간 이전 메시지만 업데이트
+    if (lastReadAt != null) {
+      if (!message.createdAt.isAfter(lastReadAt)) {
+        return message.copyWith(unreadCount: message.unreadCount - 1);
+      }
+      return message;
+    }
+
+    // 3. 둘 다 없으면 모든 메시지를 읽음 처리
+    return message.copyWith(unreadCount: message.unreadCount - 1);
+  }
+
+  /// 처리된 이벤트 키 집합에 [eventKey]를 추가하고, 무한 증가를 막기 위해
+  /// 500개 초과 시 최근 250개만 남긴다(삽입 순서 보존, 원본 로직과 동일).
+  LinkedHashSet<String> appendProcessedEvent(
+    Set<String> processedEvents,
+    String eventKey,
+  ) {
+    var result = LinkedHashSet<String>.from(processedEvents)..add(eventKey);
+    if (result.length > 500) {
+      final eventsList = result.toList();
+      result = LinkedHashSet<String>.from(
+        eventsList.sublist(eventsList.length - 250),
+      );
+    }
+    return result;
+  }
+}

--- a/lib/presentation/pages/chat/chat_room_page.dart
+++ b/lib/presentation/pages/chat/chat_room_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart' show kDebugMode;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:get_it/get_it.dart';
@@ -300,7 +301,12 @@ class _ChatRoomPageState extends State<ChatRoomPage> with WidgetsBindingObserver
       if (activeRoomTracker.activeRoomId == widget.roomId) {
         activeRoomTracker.activeRoomId = null;
       }
-    } catch (_) {}
+    } catch (e) {
+      // best-effort: dispose 중 GetIt 미등록 등은 무시하되 debug에서는 가시화.
+      if (kDebugMode) {
+        debugPrint('[ChatRoomPage] ActiveRoomTracker reset skipped: $e');
+      }
+    }
 
     if (!_chatRoomBloc.isClosed) {
       _chatRoomBloc.add(const ChatRoomClosed());
@@ -312,7 +318,12 @@ class _ChatRoomPageState extends State<ChatRoomPage> with WidgetsBindingObserver
     try {
       final notificationClickHandler = GetIt.instance<NotificationClickHandler>();
       notificationClickHandler.onSameRoomRefresh = null;
-    } catch (_) {}
+    } catch (e) {
+      // best-effort: 콜백 해제 실패는 무시하되 debug에서는 가시화.
+      if (kDebugMode) {
+        debugPrint('[ChatRoomPage] onSameRoomRefresh unregister skipped: $e');
+      }
+    }
     super.dispose();
   }
 

--- a/lib/presentation/pages/chat/chat_room_page.dart
+++ b/lib/presentation/pages/chat/chat_room_page.dart
@@ -42,6 +42,14 @@ class ChatRoomPage extends StatefulWidget {
   State<ChatRoomPage> createState() => _ChatRoomPageState();
 }
 
+/// 채팅 방(room) 전용 라이프사이클 옵저버.
+///
+/// 책임 경계(M2): 이 옵저버는 방이 열려 있는 동안의 **per-room presence와
+/// WebSocket 연결**을 담당한다 — paused 즉시 presence-inactive 전송, 1.5s
+/// 디바운스 후 ChatRoomBackgrounded(소켓 정리), iOS inactive-vs-paused 구분.
+/// 앱 전역 보안 잠금은 app.dart의 _AppLifecycleHandler가 담당한다(역할 분리).
+/// presence는 per-room이므로, 방 밖(채팅 목록)에서의 백그라운드 전환에는 별도
+/// presence 의무가 없다 — 자세한 근거는 app.dart의 _AppLifecycleHandler 주석 참고.
 class _ChatRoomPageState extends State<ChatRoomPage> with WidgetsBindingObserver {
   final _messageController = TextEditingController();
   final _scrollController = ScrollController();

--- a/lib/presentation/pages/chat/widgets/message_bubble.dart
+++ b/lib/presentation/pages/chat/widgets/message_bubble.dart
@@ -13,20 +13,27 @@ import '../../../../core/utils/save_image_to_gallery.dart';
 import '../../../../l10n/app_localizations.dart';
 import '../../../../domain/entities/message.dart';
 import '../../../../domain/entities/link_preview.dart';
-import '../../../../domain/entities/chat_room.dart';
 import '../../../blocs/chat/chat_room_bloc.dart';
 import '../../../blocs/chat/chat_room_event.dart';
 import '../../../blocs/chat/chat_list_bloc.dart';
-import '../../../blocs/chat/chat_list_state.dart';
 import '../../../blocs/settings/chat_settings_cubit.dart';
 import '../../../widgets/link_preview_card.dart';
 import '../../../widgets/link_preview_loader.dart';
 import '../../../widgets/reaction_display.dart';
 import 'package:emoji_picker_flutter/emoji_picker_flutter.dart';
-import 'video_player_page.dart';
+import 'message_bubble/auto_download_image_widget.dart';
+import 'message_bubble/dismissible_image_viewer.dart';
+import 'message_bubble/forward_room_picker_dialog.dart';
+import 'message_bubble/message_bubble_parts.dart';
 
 /// A message bubble widget that displays different types of messages.
 /// Handles text, image, and file messages with appropriate styling.
+///
+/// This is a thin dispatcher: per-content-type rendering lives in the
+/// `message_bubble/` folder (text/image/video/file/reply/forwarded/system/
+/// failed-status widgets), while the long-press action sheets and edit/delete/
+/// forward dialogs — which depend on this bubble's [message]/[isMe] and dispatch
+/// [ChatRoomBloc] events — remain here.
 class MessageBubble extends StatelessWidget {
   final Message message;
   final bool isMe;
@@ -40,191 +47,6 @@ class MessageBubble extends StatelessWidget {
   /// Check if edit time (5 minutes) has expired
   bool get _isEditTimeExpired {
     return DateTime.now().difference(message.createdAt).inMinutes >= 5;
-  }
-
-  /// Builds a reply preview shown above the message content
-  Widget _buildReplyPreview(BuildContext context) {
-    if (message.replyToMessageId == null) return const SizedBox.shrink();
-
-    // Try the embedded replyToMessage first, then look up from BLoC state
-    final replyMsg = message.replyToMessage ??
-        context.read<ChatRoomBloc>().state.messages
-            .where((m) => m.id == message.replyToMessageId)
-            .firstOrNull;
-
-    final l10n = AppLocalizations.of(context)!;
-    final previewText = replyMsg?.isDeleted == true
-        ? l10n.chatDeletedMessage
-        : (replyMsg?.content ?? l10n.chatOriginalMessageNotFound);
-    final senderName = replyMsg?.senderNickname ?? l10n.chatUnknownSender;
-
-    return Container(
-      margin: const EdgeInsets.only(bottom: 4),
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-      constraints: BoxConstraints(
-        maxWidth: MediaQuery.of(context).size.width * 0.55,
-      ),
-      decoration: BoxDecoration(
-        color: isMe
-            ? Colors.white.withValues(alpha: 0.15)
-            : AppColors.primary.withValues(alpha: 0.08),
-        borderRadius: BorderRadius.circular(8),
-        border: Border(
-          left: BorderSide(
-            color: isMe ? Colors.white.withValues(alpha: 0.5) : AppColors.primary,
-            width: 2,
-          ),
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            senderName,
-            style: TextStyle(
-              fontSize: 11,
-              fontWeight: FontWeight.w600,
-              color: isMe ? Colors.white.withValues(alpha: 0.9) : AppColors.primary,
-            ),
-          ),
-          Text(
-            previewText,
-            style: TextStyle(
-              fontSize: 12,
-              color: isMe
-                  ? Colors.white.withValues(alpha: 0.7)
-                  : context.textSecondaryColor,
-            ),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-          ),
-        ],
-      ),
-    );
-  }
-
-  /// Builds a "forwarded" indicator shown above the message
-  Widget _buildForwardedIndicator(BuildContext context) {
-    if (message.forwardedFromMessageId == null) return const SizedBox.shrink();
-
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 4),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Icon(
-            Icons.forward,
-            size: 12,
-            color: isMe ? Colors.white.withValues(alpha: 0.6) : context.textSecondaryColor,
-          ),
-          const SizedBox(width: 4),
-          Text(
-            AppLocalizations.of(context)!.chatForwarded,
-            style: TextStyle(
-              fontSize: 11,
-              fontStyle: FontStyle.italic,
-              color: isMe ? Colors.white.withValues(alpha: 0.6) : context.textSecondaryColor,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  /// Builds failed status widget with retry and delete buttons
-  Widget _buildFailedStatusWidget(BuildContext context) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        // 전송 실패 아이콘
-        Icon(
-          Icons.error_outline,
-          size: 14,
-          color: Colors.red[400],
-        ),
-        const SizedBox(width: 4),
-        // 재전송 버튼
-        GestureDetector(
-          onTap: () {
-            if (message.localId != null) {
-              context.read<ChatRoomBloc>().add(MessageRetryRequested(message.localId!));
-            }
-          },
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-            decoration: BoxDecoration(
-              color: AppColors.primary.withValues(alpha: 0.1),
-              borderRadius: BorderRadius.circular(4),
-            ),
-            child: Text(
-              AppLocalizations.of(context)!.chatResend,
-              style: const TextStyle(
-                color: AppColors.primary,
-                fontSize: 11,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ),
-        ),
-        const SizedBox(width: 4),
-        // 삭제 버튼
-        GestureDetector(
-          onTap: () {
-            if (message.localId != null) {
-              context.read<ChatRoomBloc>().add(PendingMessageDeleteRequested(message.localId!));
-            }
-          },
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-            decoration: BoxDecoration(
-              color: Colors.red.withValues(alpha: 0.1),
-              borderRadius: BorderRadius.circular(4),
-            ),
-            child: Text(
-              AppLocalizations.of(context)!.commonDelete,
-              style: TextStyle(
-                color: Colors.red[400],
-                fontSize: 11,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-
-  /// Returns appropriate icon for file type
-  IconData _getFileIcon(String? contentType) {
-    if (contentType == null) return Icons.insert_drive_file;
-    if (contentType.startsWith('image/')) return Icons.image;
-    if (contentType.startsWith('video/')) return Icons.videocam;
-    if (contentType.startsWith('audio/')) return Icons.audiotrack;
-    if (contentType.contains('pdf')) return Icons.picture_as_pdf;
-    if (contentType.contains('word') || contentType.contains('document')) {
-      return Icons.description;
-    }
-    if (contentType.contains('sheet') || contentType.contains('excel')) {
-      return Icons.table_chart;
-    }
-    if (contentType.contains('presentation') || contentType.contains('powerpoint')) {
-      return Icons.slideshow;
-    }
-    if (contentType.contains('zip') || contentType.contains('rar') || contentType.contains('tar')) {
-      return Icons.folder_zip;
-    }
-    return Icons.insert_drive_file;
-  }
-
-  /// Formats file size to human readable format
-  String _formatFileSize(int bytes) {
-    if (bytes < 1024) return '$bytes B';
-    if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
-    if (bytes < 1024 * 1024 * 1024) {
-      return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
-    }
-    return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
   }
 
   /// Builds clickable text spans for URLs in message content
@@ -394,7 +216,7 @@ class MessageBubble extends StatelessWidget {
         opaque: false,
         barrierColor: Colors.black,
         pageBuilder: (context, animation, secondaryAnimation) {
-          return _DismissibleImageViewer(
+          return DismissibleImageViewer(
             imageUrl: imageUrl,
             heroTag: heroTag,
             onSaveToGallery: kIsWeb ? null : () => _saveImageToGallery(context, imageUrl),
@@ -509,7 +331,7 @@ class MessageBubble extends StatelessWidget {
       context: context,
       builder: (dialogContext) => BlocProvider.value(
         value: chatListBloc,
-        child: _ForwardRoomPickerDialog(
+        child: ForwardRoomPickerDialog(
           onRoomSelected: (roomId) {
             chatRoomBloc.add(MessageForwardRequested(
               messageId: message.id,
@@ -801,42 +623,15 @@ class MessageBubble extends StatelessWidget {
     );
   }
 
-  @override
-  Widget build(BuildContext context) {
-    // System messages are displayed centered
-    if (message.isSystemMessage) {
-      return Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        child: Center(
-          child: Container(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            decoration: BoxDecoration(
-              color: context.dividerColor,
-              borderRadius: BorderRadius.circular(16),
-            ),
-            child: Text(
-              message.content,
-              style: TextStyle(
-                color: context.textSecondaryColor,
-                fontSize: 13,
-              ),
-              textAlign: TextAlign.center,
-            ),
-          ),
-        ),
-      );
-    }
-
-    // Time and status widget (카카오톡 스타일)
-    Widget timeWidget;
-
+  /// Builds the time + send-status widget shown beside the bubble.
+  Widget _buildTimeWidget(BuildContext context) {
     // 전송 실패 시: 재전송/삭제 버튼
     if (message.isFailed && isMe) {
-      timeWidget = _buildFailedStatusWidget(context);
+      return FailedStatusWidget(message: message);
     }
     // 전송 중: 로딩 인디케이터
-    else if (message.isPending && isMe) {
-      timeWidget = const SizedBox(
+    if (message.isPending && isMe) {
+      return const SizedBox(
         width: 12,
         height: 12,
         child: CircularProgressIndicator(
@@ -846,36 +641,34 @@ class MessageBubble extends StatelessWidget {
       );
     }
     // 전송 완료: 읽지 않음 개수 + 시간
-    else {
-      timeWidget = Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          if (message.unreadCount > 0 && isMe)
-            Padding(
-              padding: const EdgeInsets.only(right: 4),
-              child: Text(
-                '${message.unreadCount}',
-                style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                      color: AppColors.primary,
-                      fontWeight: FontWeight.w600,
-                      fontSize: 11,
-                    ),
-              ),
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (message.unreadCount > 0 && isMe)
+          Padding(
+            padding: const EdgeInsets.only(right: 4),
+            child: Text(
+              '${message.unreadCount}',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: AppColors.primary,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 11,
+                  ),
             ),
-          Text(
-            AppDateUtils.formatMessageTime(message.createdAt),
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: context.textSecondaryColor,
-                  fontSize: 11,
-                ),
           ),
-        ],
-      );
-    }
+        Text(
+          AppDateUtils.formatMessageTime(message.createdAt),
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: context.textSecondaryColor,
+                fontSize: 11,
+              ),
+        ),
+      ],
+    );
+  }
 
-    // Message bubble content
-    Widget bubbleWidget;
-
+  /// Builds the content bubble for the message based on its type.
+  Widget _buildBubble(BuildContext context) {
     // Image message
     if (message.type == MessageType.image && message.fileUrl != null) {
       final imageUrl = message.fileUrl!;
@@ -892,7 +685,7 @@ class MessageBubble extends StatelessWidget {
       final chatSettings = context.read<ChatSettingsCubit>().state.settings;
       final autoDownload = chatSettings.autoDownloadImagesOnWifi; // Use wifi setting as the general toggle
 
-      bubbleWidget = _AutoDownloadImageWidget(
+      return AutoDownloadImageWidget(
         imageUrl: imageUrl,
         heroTag: heroTag,
         isMe: isMe,
@@ -902,252 +695,101 @@ class MessageBubble extends StatelessWidget {
       );
     }
     // Video message
-    else if (message.fileUrl != null && message.fileContentType?.startsWith('video/') == true) {
-      bubbleWidget = GestureDetector(
-        onTap: () {
-          Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (_) => VideoPlayerPage(
-                videoUrl: message.fileUrl!,
-                title: message.fileName,
-              ),
-            ),
-          );
-        },
-        child: ClipRRect(
-          borderRadius: BorderRadius.only(
-            topLeft: const Radius.circular(18),
-            topRight: const Radius.circular(18),
-            bottomLeft: Radius.circular(isMe ? 18 : 4),
-            bottomRight: Radius.circular(isMe ? 4 : 18),
-          ),
-          child: Container(
-            constraints: BoxConstraints(
-              maxWidth: MediaQuery.of(context).size.width * 0.65,
-            ),
-            width: 200,
-            height: 150,
-            color: Colors.black87,
-            child: Stack(
-              alignment: Alignment.center,
-              children: [
-                if (message.thumbnailUrl != null)
-                  Image.network(
-                    message.thumbnailUrl!,
-                    fit: BoxFit.cover,
-                    width: double.infinity,
-                    height: double.infinity,
-                    errorBuilder: (_, __, ___) => const SizedBox.shrink(),
-                  ),
-                Container(
-                  decoration: BoxDecoration(
-                    color: Colors.black.withValues(alpha: 0.3),
-                    shape: BoxShape.circle,
-                  ),
-                  padding: const EdgeInsets.all(12),
-                  child: const Icon(
-                    Icons.play_arrow,
-                    color: Colors.white,
-                    size: 32,
-                  ),
-                ),
-                // File name and size at the bottom
-                Positioned(
-                  bottom: 8,
-                  left: 8,
-                  right: 8,
-                  child: Row(
-                    children: [
-                      const Icon(Icons.videocam, color: Colors.white70, size: 14),
-                      const SizedBox(width: 4),
-                      Expanded(
-                        child: Text(
-                          message.fileName ?? AppLocalizations.of(context)!.chatVideo,
-                          style: const TextStyle(
-                            color: Colors.white70,
-                            fontSize: 11,
-                          ),
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      );
+    if (message.fileUrl != null && message.fileContentType?.startsWith('video/') == true) {
+      return VideoBubble(message: message, isMe: isMe);
     }
     // File message
-    else if (message.type == MessageType.file && message.fileUrl != null) {
-      bubbleWidget = GestureDetector(
+    if (message.type == MessageType.file && message.fileUrl != null) {
+      return FileBubble(
+        message: message,
+        isMe: isMe,
         onTap: () => _downloadFile(context, message.fileUrl!, message.fileName),
         onLongPress: () => _showFileOptions(context, message.fileUrl!, message.fileName),
-        child: Container(
-          constraints: BoxConstraints(
-            maxWidth: MediaQuery.of(context).size.width * 0.65,
-          ),
-          padding: const EdgeInsets.all(12),
-          decoration: BoxDecoration(
-            color: isMe ? context.myMessageBubbleColor : context.otherMessageBubbleColor,
-            borderRadius: BorderRadius.only(
-              topLeft: const Radius.circular(18),
-              topRight: const Radius.circular(18),
-              bottomLeft: Radius.circular(isMe ? 18 : 4),
-              bottomRight: Radius.circular(isMe ? 4 : 18),
-            ),
-            boxShadow: isMe
-                ? [
-                    BoxShadow(
-                      color: AppColors.primary.withValues(alpha: 0.15),
-                      blurRadius: 4,
-                      offset: const Offset(0, 2),
-                    ),
-                  ]
-                : [
-                    BoxShadow(
-                      color: Colors.black.withValues(alpha: 0.03),
-                      blurRadius: 2,
-                      offset: const Offset(0, 1),
-                    ),
-                  ],
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Container(
-                padding: const EdgeInsets.all(10),
-                decoration: BoxDecoration(
-                  color: isMe
-                      ? Colors.white.withValues(alpha: 0.2)
-                      : AppColors.primary.withValues(alpha: 0.1),
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: Icon(
-                  _getFileIcon(message.fileContentType),
-                  color: isMe ? Colors.white : AppColors.primary,
-                  size: 24,
-                ),
-              ),
-              const SizedBox(width: 12),
-              Flexible(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      message.fileName ?? AppLocalizations.of(context)!.chatFileFallback,
-                      style: TextStyle(
-                        color: isMe ? Colors.white : context.textPrimaryColor,
-                        fontSize: 14,
-                        fontWeight: FontWeight.w500,
-                      ),
-                      maxLines: 2,
-                      overflow: TextOverflow.ellipsis,
-                    ),
-                    Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        if (message.fileSize != null)
-                          Text(
-                            _formatFileSize(message.fileSize!),
-                            style: TextStyle(
-                              color: isMe
-                                  ? Colors.white.withValues(alpha: 0.7)
-                                  : context.textSecondaryColor,
-                              fontSize: 12,
-                            ),
-                          ),
-                        const SizedBox(width: 8),
-                        Icon(
-                          Icons.download,
-                          size: 14,
-                          color: isMe
-                              ? Colors.white.withValues(alpha: 0.7)
-                              : context.textSecondaryColor,
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
       );
     }
     // Text message (default)
-    else {
-      final textColor = isMe ? Colors.white : context.textPrimaryColor;
+    final textColor = isMe ? Colors.white : context.textPrimaryColor;
 
-      // URL detection (show preview for first URL only)
-      final urlMatches = urlPattern.allMatches(message.displayContent);
-      final firstUrlRaw = urlMatches.isNotEmpty ? urlMatches.first.group(0) : null;
-      final firstUrl = firstUrlRaw != null ? normalizeUrl(firstUrlRaw) : null;
+    // URL detection (show preview for first URL only)
+    final urlMatches = urlPattern.allMatches(message.displayContent);
+    final firstUrlRaw = urlMatches.isNotEmpty ? urlMatches.first.group(0) : null;
+    final firstUrl = firstUrlRaw != null ? normalizeUrl(firstUrlRaw) : null;
 
-      bubbleWidget = Container(
-        constraints: BoxConstraints(
-          maxWidth: MediaQuery.of(context).size.width * 0.65,
+    return Container(
+      constraints: BoxConstraints(
+        maxWidth: MediaQuery.of(context).size.width * 0.65,
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: isMe ? context.myMessageBubbleColor : context.otherMessageBubbleColor,
+        borderRadius: BorderRadius.only(
+          topLeft: const Radius.circular(18),
+          topRight: const Radius.circular(18),
+          bottomLeft: Radius.circular(isMe ? 18 : 4),
+          bottomRight: Radius.circular(isMe ? 4 : 18),
         ),
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-        decoration: BoxDecoration(
-          color: isMe ? context.myMessageBubbleColor : context.otherMessageBubbleColor,
-          borderRadius: BorderRadius.only(
-            topLeft: const Radius.circular(18),
-            topRight: const Radius.circular(18),
-            bottomLeft: Radius.circular(isMe ? 18 : 4),
-            bottomRight: Radius.circular(isMe ? 4 : 18),
-          ),
-          boxShadow: isMe
-              ? [
-                  BoxShadow(
-                    color: AppColors.primary.withValues(alpha: 0.15),
-                    blurRadius: 4,
-                    offset: const Offset(0, 2),
-                  ),
-                ]
-              : [
-                  BoxShadow(
-                    color: Colors.black.withValues(alpha: 0.03),
-                    blurRadius: 2,
-                    offset: const Offset(0, 1),
-                  ),
-                ],
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            _buildForwardedIndicator(context),
-            _buildReplyPreview(context),
-            RichText(
-              text: TextSpan(
-                children: _buildTextSpans(context, message.displayContent, textColor),
-              ),
-            ),
-            // Link preview
-            if (message.hasLinkPreview)
-              LinkPreviewCard(
-                preview: LinkPreview(
-                  url: message.linkPreviewUrl!,
-                  title: message.linkPreviewTitle,
-                  description: message.linkPreviewDescription,
-                  imageUrl: message.linkPreviewImageUrl,
+        boxShadow: isMe
+            ? [
+                BoxShadow(
+                  color: AppColors.primary.withValues(alpha: 0.15),
+                  blurRadius: 4,
+                  offset: const Offset(0, 2),
                 ),
-                isMe: isMe,
-                maxWidth: MediaQuery.of(context).size.width * 0.6,
-              )
-            else if (firstUrl != null)
-              LinkPreviewLoader(
-                url: firstUrl,
-                isMe: isMe,
-                maxWidth: MediaQuery.of(context).size.width * 0.6,
+              ]
+            : [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.03),
+                  blurRadius: 2,
+                  offset: const Offset(0, 1),
+                ),
+              ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ForwardedIndicator(message: message, isMe: isMe),
+          ReplyPreview(message: message, isMe: isMe),
+          RichText(
+            text: TextSpan(
+              children: _buildTextSpans(context, message.displayContent, textColor),
+            ),
+          ),
+          // Link preview
+          if (message.hasLinkPreview)
+            LinkPreviewCard(
+              preview: LinkPreview(
+                url: message.linkPreviewUrl!,
+                title: message.linkPreviewTitle,
+                description: message.linkPreviewDescription,
+                imageUrl: message.linkPreviewImageUrl,
               ),
-          ],
-        ),
-      );
+              isMe: isMe,
+              maxWidth: MediaQuery.of(context).size.width * 0.6,
+            )
+          else if (firstUrl != null)
+            LinkPreviewLoader(
+              url: firstUrl,
+              isMe: isMe,
+              maxWidth: MediaQuery.of(context).size.width * 0.6,
+            ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // System messages are displayed centered
+    if (message.isSystemMessage) {
+      return SystemMessageBubble(message: message);
     }
+
+    // Time and status widget (카카오톡 스타일)
+    final Widget timeWidget = _buildTimeWidget(context);
+
+    // Message bubble content
+    final Widget bubbleWidget = _buildBubble(context);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
@@ -1240,430 +882,6 @@ class MessageBubble extends StatelessWidget {
           ),
         ],
       ),
-    );
-  }
-}
-
-/// 자동 다운로드 설정에 따라 이미지를 로드하는 위젯
-class _AutoDownloadImageWidget extends StatefulWidget {
-  final String imageUrl;
-  final String? heroTag;
-  final bool isMe;
-  final bool autoDownloadEnabled;
-  final VoidCallback onTapFullScreen;
-  final Function(BuildContext, String) onLongPress;
-
-  const _AutoDownloadImageWidget({
-    required this.imageUrl,
-    this.heroTag,
-    required this.isMe,
-    required this.autoDownloadEnabled,
-    required this.onTapFullScreen,
-    required this.onLongPress,
-  });
-
-  @override
-  State<_AutoDownloadImageWidget> createState() => _AutoDownloadImageWidgetState();
-}
-
-class _AutoDownloadImageWidgetState extends State<_AutoDownloadImageWidget> {
-  late bool _shouldLoad;
-
-  @override
-  void initState() {
-    super.initState();
-    _shouldLoad = widget.autoDownloadEnabled;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    if (!_shouldLoad) {
-      return GestureDetector(
-        onTap: () {
-          setState(() {
-            _shouldLoad = true;
-          });
-        },
-        child: ClipRRect(
-          borderRadius: BorderRadius.only(
-            topLeft: const Radius.circular(18),
-            topRight: const Radius.circular(18),
-            bottomLeft: Radius.circular(widget.isMe ? 18 : 4),
-            bottomRight: Radius.circular(widget.isMe ? 4 : 18),
-          ),
-          child: Container(
-            width: 200,
-            height: 150,
-            color: context.dividerColor,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(
-                  Icons.image_outlined,
-                  color: context.textSecondaryColor,
-                  size: 40,
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  AppLocalizations.of(context)!.chatTapToViewImage,
-                  style: TextStyle(
-                    color: context.textSecondaryColor,
-                    fontSize: 12,
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      );
-    }
-
-    // 버블 썸네일은 화면상 maxWidth(= 화면폭 * 0.65) 로만 표시되므로,
-    // 디바이스 픽셀비를 곱한 적정 폭으로 memCacheWidth 를 지정해 서버 원본 해상도가
-    // 그대로 디코딩되어 메모리에 상주하는 것을 방지한다. (전체화면 뷰어는 풀해상도 유지)
-    final mq = MediaQuery.of(context);
-    final thumbCacheWidth =
-        (mq.size.width * 0.65 * mq.devicePixelRatio).round();
-
-    final cachedImage = CachedNetworkImage(
-      imageUrl: widget.imageUrl,
-      fit: BoxFit.cover,
-      memCacheWidth: thumbCacheWidth,
-      placeholder: (context, url) => Container(
-        width: 200,
-        height: 150,
-        color: context.dividerColor,
-        child: const Center(
-          child: CircularProgressIndicator(strokeWidth: 2),
-        ),
-      ),
-      errorWidget: (context, url, error) => Container(
-        width: 200,
-        height: 150,
-        color: context.dividerColor,
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(Icons.broken_image, color: context.textSecondaryColor, size: 40),
-            const SizedBox(height: 8),
-            Text(
-              AppLocalizations.of(context)!.chatImageLoadFailed,
-              style: TextStyle(color: context.textSecondaryColor, fontSize: 12),
-            ),
-          ],
-        ),
-      ),
-    );
-
-    final borderRadius = BorderRadius.only(
-      topLeft: const Radius.circular(18),
-      topRight: const Radius.circular(18),
-      bottomLeft: Radius.circular(widget.isMe ? 18 : 4),
-      bottomRight: Radius.circular(widget.isMe ? 4 : 18),
-    );
-
-    // ClipRRect를 Hero 자식으로 넣어 Hero 비행 중에도 동일한 클리핑이 유지되도록 함.
-    // (ClipRRect를 Hero 바깥에 두면 비행 오버레이에서는 클리핑이 적용되지 않아 시각적 글리치 발생)
-    Widget imageChild = ClipRRect(
-      borderRadius: borderRadius,
-      child: Container(
-        constraints: BoxConstraints(
-          maxWidth: MediaQuery.of(context).size.width * 0.65,
-          maxHeight: 250,
-        ),
-        child: cachedImage,
-      ),
-    );
-
-    return GestureDetector(
-      onTap: widget.onTapFullScreen,
-      onLongPress: () => widget.onLongPress(context, widget.imageUrl),
-      child: widget.heroTag != null
-          ? Hero(
-              tag: widget.heroTag!,
-              // 비행 중에도 버블 측 둥근 모서리가 자연스럽게 유지됨
-              flightShuttleBuilder: (_, animation, direction, __, ___) {
-                return AnimatedBuilder(
-                  animation: animation,
-                  builder: (context, child) {
-                    // 출발(버블) → 도착(전체화면) 방향에 따라 radius를 보간
-                    final t = direction == HeroFlightDirection.push
-                        ? animation.value
-                        : 1 - animation.value;
-                    final radius = BorderRadius.lerp(
-                      borderRadius,
-                      BorderRadius.zero,
-                      t,
-                    )!;
-                    return ClipRRect(
-                      borderRadius: radius,
-                      child: Container(
-                        constraints: BoxConstraints(
-                          maxWidth: MediaQuery.of(context).size.width * 0.65,
-                          maxHeight: 250,
-                        ),
-                        child: cachedImage,
-                      ),
-                    );
-                  },
-                );
-              },
-              child: imageChild,
-            )
-          : imageChild,
-    );
-  }
-}
-
-/// 드래그로 닫을 수 있는 전체화면 이미지 뷰어 (카카오톡 스타일)
-class _DismissibleImageViewer extends StatefulWidget {
-  final String imageUrl;
-  final String? heroTag;
-  final VoidCallback? onSaveToGallery;
-
-  const _DismissibleImageViewer({
-    required this.imageUrl,
-    this.heroTag,
-    this.onSaveToGallery,
-  });
-
-  @override
-  State<_DismissibleImageViewer> createState() => _DismissibleImageViewerState();
-}
-
-class _DismissibleImageViewerState extends State<_DismissibleImageViewer>
-    with SingleTickerProviderStateMixin {
-  double _dragOffset = 0;
-  double _dragVelocity = 0;
-  late AnimationController _animationController;
-  late Animation<double> _animation;
-
-  // InteractiveViewer 줌 상태 추적용 컨트롤러.
-  // scale > 1.0 일 때만 panEnabled = true 로 설정해 드래그-투-디스미스와 충돌 방지.
-  final TransformationController _transformationController =
-      TransformationController();
-  bool _panEnabled = false;
-
-  static const double _dismissThreshold = 100;
-  static const double _velocityThreshold = 500;
-
-  @override
-  void initState() {
-    super.initState();
-    _animationController = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 200),
-    );
-    _animation = Tween<double>(begin: 0, end: 0).animate(
-      CurvedAnimation(parent: _animationController, curve: Curves.easeOut),
-    );
-    _animationController.addListener(() {
-      setState(() {
-        _dragOffset = _animation.value;
-      });
-    });
-  }
-
-  @override
-  void dispose() {
-    _animationController.dispose();
-    _transformationController.dispose();
-    super.dispose();
-  }
-
-  void _onInteractionUpdate(ScaleUpdateDetails details) {
-    // panEnabled 분기에 필요한 건 (scale > 1.0) boolean 전환 시점뿐이므로,
-    // scale 값 자체가 아니라 boolean 이 직전 값과 달라질 때만 setState 하여
-    // 줌 중 build/CachedNetworkImage 의 불필요한 리빌드를 줄인다.
-    final panEnabled =
-        _transformationController.value.getMaxScaleOnAxis() > 1.0;
-    if (panEnabled != _panEnabled) {
-      setState(() {
-        _panEnabled = panEnabled;
-      });
-    }
-  }
-
-  void _onVerticalDragUpdate(DragUpdateDetails details) {
-    setState(() {
-      _dragOffset += details.delta.dy;
-    });
-  }
-
-  void _onVerticalDragEnd(DragEndDetails details) {
-    _dragVelocity = details.velocity.pixelsPerSecond.dy;
-
-    final shouldDismiss = _dragOffset.abs() > _dismissThreshold ||
-        _dragVelocity.abs() > _velocityThreshold;
-
-    if (shouldDismiss) {
-      Navigator.of(context).pop();
-    } else {
-      // Snap back to center
-      _animation = Tween<double>(begin: _dragOffset, end: 0).animate(
-        CurvedAnimation(parent: _animationController, curve: Curves.easeOut),
-      );
-      _animationController.forward(from: 0);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final opacity = (1 - (_dragOffset.abs() / 300)).clamp(0.3, 1.0);
-    final scale = (1 - (_dragOffset.abs() / 1000)).clamp(0.8, 1.0);
-
-    return Scaffold(
-      backgroundColor: Colors.black.withValues(alpha: opacity),
-      appBar: AppBar(
-        backgroundColor: Colors.transparent,
-        iconTheme: IconThemeData(color: Colors.white.withValues(alpha: opacity)),
-        elevation: 0,
-        actions: [
-          if (widget.onSaveToGallery != null)
-            IconButton(
-              icon: Icon(Icons.download_rounded,
-                  color: Colors.white.withValues(alpha: opacity)),
-              tooltip: AppLocalizations.of(context)!.chatSaveToGallery,
-              onPressed: widget.onSaveToGallery,
-            ),
-        ],
-      ),
-      extendBodyBehindAppBar: true,
-      body: GestureDetector(
-        onVerticalDragUpdate: _onVerticalDragUpdate,
-        onVerticalDragEnd: _onVerticalDragEnd,
-        onTap: () => Navigator.of(context).pop(),
-        child: Container(
-          color: Colors.transparent,
-          child: Center(
-            child: Transform.translate(
-              offset: Offset(0, _dragOffset),
-              child: Transform.scale(
-                scale: scale,
-                child: InteractiveViewer(
-                  // scale == 1.0 일 때 pan 을 비활성화하여 드래그-투-디스미스 제스처가 동작하도록 함.
-                  // zoom 상태에서는 pan 활성화하여 정상 이동 가능.
-                  panEnabled: _panEnabled,
-                  transformationController: _transformationController,
-                  onInteractionUpdate: _onInteractionUpdate,
-                  minScale: 0.5,
-                  maxScale: 4,
-                  child: Builder(
-                    builder: (context) {
-                      final image = CachedNetworkImage(
-                        imageUrl: widget.imageUrl,
-                        fit: BoxFit.contain,
-                        placeholder: (context, url) => const Center(
-                          child: CircularProgressIndicator(
-                            color: Colors.white,
-                          ),
-                        ),
-                        errorWidget: (context, url, error) => const Center(
-                          child: Icon(Icons.broken_image, color: Colors.white54, size: 80),
-                        ),
-                      );
-                      if (widget.heroTag != null) {
-                        return Hero(tag: widget.heroTag!, child: image);
-                      }
-                      return image;
-                    },
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// Dialog for selecting a chat room to forward a message to.
-class _ForwardRoomPickerDialog extends StatefulWidget {
-  final ValueChanged<int> onRoomSelected;
-
-  const _ForwardRoomPickerDialog({required this.onRoomSelected});
-
-  @override
-  State<_ForwardRoomPickerDialog> createState() => _ForwardRoomPickerDialogState();
-}
-
-class _ForwardRoomPickerDialogState extends State<_ForwardRoomPickerDialog> {
-  String _searchQuery = '';
-
-  @override
-  Widget build(BuildContext context) {
-    return AlertDialog(
-      title: Text(AppLocalizations.of(context)!.chatSelectRoom),
-      content: SizedBox(
-        width: double.maxFinite,
-        height: 400,
-        child: Column(
-          children: [
-            TextField(
-              decoration: InputDecoration(
-                hintText: AppLocalizations.of(context)!.chatSearchHint,
-                prefixIcon: const Icon(Icons.search),
-                border: OutlineInputBorder(
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-              ),
-              onChanged: (value) => setState(() => _searchQuery = value.toLowerCase()),
-            ),
-            const SizedBox(height: 12),
-            Expanded(
-              child: BlocBuilder<ChatListBloc, ChatListState>(
-                builder: (context, state) {
-                  final rooms = state.chatRooms.where((room) {
-                    if (_searchQuery.isEmpty) return true;
-                    final name = room.displayName.toLowerCase();
-                    return name.contains(_searchQuery);
-                  }).toList();
-
-                  if (rooms.isEmpty) {
-                    return Center(child: Text(AppLocalizations.of(context)!.chatRoomListEmpty));
-                  }
-
-                  return ListView.builder(
-                    itemCount: rooms.length,
-                    itemBuilder: (context, index) {
-                      final room = rooms[index];
-                      return ListTile(
-                        leading: CircleAvatar(
-                          backgroundColor: AppColors.primaryLight,
-                          child: Icon(
-                            room.type == ChatRoomType.group
-                                ? Icons.group
-                                : Icons.person,
-                            color: Colors.white,
-                            size: 20,
-                          ),
-                        ),
-                        title: Text(
-                          room.displayName,
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                        onTap: () {
-                          Navigator.pop(context);
-                          widget.onRoomSelected(room.id);
-                        },
-                      );
-                    },
-                  );
-                },
-              ),
-            ),
-          ],
-        ),
-      ),
-      actions: [
-        TextButton(
-          onPressed: () => Navigator.pop(context),
-          child: Text(AppLocalizations.of(context)!.commonCancel),
-        ),
-      ],
     );
   }
 }

--- a/lib/presentation/pages/chat/widgets/message_bubble/auto_download_image_widget.dart
+++ b/lib/presentation/pages/chat/widgets/message_bubble/auto_download_image_widget.dart
@@ -1,0 +1,176 @@
+import 'package:flutter/material.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import '../../../../../core/theme/app_colors.dart';
+import '../../../../../l10n/app_localizations.dart';
+
+/// 자동 다운로드 설정에 따라 이미지를 로드하는 위젯
+class AutoDownloadImageWidget extends StatefulWidget {
+  final String imageUrl;
+  final String? heroTag;
+  final bool isMe;
+  final bool autoDownloadEnabled;
+  final VoidCallback onTapFullScreen;
+  final Function(BuildContext, String) onLongPress;
+
+  const AutoDownloadImageWidget({
+    super.key,
+    required this.imageUrl,
+    this.heroTag,
+    required this.isMe,
+    required this.autoDownloadEnabled,
+    required this.onTapFullScreen,
+    required this.onLongPress,
+  });
+
+  @override
+  State<AutoDownloadImageWidget> createState() => _AutoDownloadImageWidgetState();
+}
+
+class _AutoDownloadImageWidgetState extends State<AutoDownloadImageWidget> {
+  late bool _shouldLoad;
+
+  @override
+  void initState() {
+    super.initState();
+    _shouldLoad = widget.autoDownloadEnabled;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_shouldLoad) {
+      return GestureDetector(
+        onTap: () {
+          setState(() {
+            _shouldLoad = true;
+          });
+        },
+        child: ClipRRect(
+          borderRadius: BorderRadius.only(
+            topLeft: const Radius.circular(18),
+            topRight: const Radius.circular(18),
+            bottomLeft: Radius.circular(widget.isMe ? 18 : 4),
+            bottomRight: Radius.circular(widget.isMe ? 4 : 18),
+          ),
+          child: Container(
+            width: 200,
+            height: 150,
+            color: context.dividerColor,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.image_outlined,
+                  color: context.textSecondaryColor,
+                  size: 40,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  AppLocalizations.of(context)!.chatTapToViewImage,
+                  style: TextStyle(
+                    color: context.textSecondaryColor,
+                    fontSize: 12,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    // 버블 썸네일은 화면상 maxWidth(= 화면폭 * 0.65) 로만 표시되므로,
+    // 디바이스 픽셀비를 곱한 적정 폭으로 memCacheWidth 를 지정해 서버 원본 해상도가
+    // 그대로 디코딩되어 메모리에 상주하는 것을 방지한다. (전체화면 뷰어는 풀해상도 유지)
+    final mq = MediaQuery.of(context);
+    final thumbCacheWidth =
+        (mq.size.width * 0.65 * mq.devicePixelRatio).round();
+
+    final cachedImage = CachedNetworkImage(
+      imageUrl: widget.imageUrl,
+      fit: BoxFit.cover,
+      memCacheWidth: thumbCacheWidth,
+      placeholder: (context, url) => Container(
+        width: 200,
+        height: 150,
+        color: context.dividerColor,
+        child: const Center(
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      ),
+      errorWidget: (context, url, error) => Container(
+        width: 200,
+        height: 150,
+        color: context.dividerColor,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.broken_image, color: context.textSecondaryColor, size: 40),
+            const SizedBox(height: 8),
+            Text(
+              AppLocalizations.of(context)!.chatImageLoadFailed,
+              style: TextStyle(color: context.textSecondaryColor, fontSize: 12),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final borderRadius = BorderRadius.only(
+      topLeft: const Radius.circular(18),
+      topRight: const Radius.circular(18),
+      bottomLeft: Radius.circular(widget.isMe ? 18 : 4),
+      bottomRight: Radius.circular(widget.isMe ? 4 : 18),
+    );
+
+    // ClipRRect를 Hero 자식으로 넣어 Hero 비행 중에도 동일한 클리핑이 유지되도록 함.
+    // (ClipRRect를 Hero 바깥에 두면 비행 오버레이에서는 클리핑이 적용되지 않아 시각적 글리치 발생)
+    Widget imageChild = ClipRRect(
+      borderRadius: borderRadius,
+      child: Container(
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.of(context).size.width * 0.65,
+          maxHeight: 250,
+        ),
+        child: cachedImage,
+      ),
+    );
+
+    return GestureDetector(
+      onTap: widget.onTapFullScreen,
+      onLongPress: () => widget.onLongPress(context, widget.imageUrl),
+      child: widget.heroTag != null
+          ? Hero(
+              tag: widget.heroTag!,
+              // 비행 중에도 버블 측 둥근 모서리가 자연스럽게 유지됨
+              flightShuttleBuilder: (_, animation, direction, __, ___) {
+                return AnimatedBuilder(
+                  animation: animation,
+                  builder: (context, child) {
+                    // 출발(버블) → 도착(전체화면) 방향에 따라 radius를 보간
+                    final t = direction == HeroFlightDirection.push
+                        ? animation.value
+                        : 1 - animation.value;
+                    final radius = BorderRadius.lerp(
+                      borderRadius,
+                      BorderRadius.zero,
+                      t,
+                    )!;
+                    return ClipRRect(
+                      borderRadius: radius,
+                      child: Container(
+                        constraints: BoxConstraints(
+                          maxWidth: MediaQuery.of(context).size.width * 0.65,
+                          maxHeight: 250,
+                        ),
+                        child: cachedImage,
+                      ),
+                    );
+                  },
+                );
+              },
+              child: imageChild,
+            )
+          : imageChild,
+    );
+  }
+}

--- a/lib/presentation/pages/chat/widgets/message_bubble/dismissible_image_viewer.dart
+++ b/lib/presentation/pages/chat/widgets/message_bubble/dismissible_image_viewer.dart
@@ -1,0 +1,167 @@
+import 'package:flutter/material.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import '../../../../../l10n/app_localizations.dart';
+
+/// 드래그로 닫을 수 있는 전체화면 이미지 뷰어 (카카오톡 스타일)
+class DismissibleImageViewer extends StatefulWidget {
+  final String imageUrl;
+  final String? heroTag;
+  final VoidCallback? onSaveToGallery;
+
+  const DismissibleImageViewer({
+    super.key,
+    required this.imageUrl,
+    this.heroTag,
+    this.onSaveToGallery,
+  });
+
+  @override
+  State<DismissibleImageViewer> createState() => _DismissibleImageViewerState();
+}
+
+class _DismissibleImageViewerState extends State<DismissibleImageViewer>
+    with SingleTickerProviderStateMixin {
+  double _dragOffset = 0;
+  double _dragVelocity = 0;
+  late AnimationController _animationController;
+  late Animation<double> _animation;
+
+  // InteractiveViewer 줌 상태 추적용 컨트롤러.
+  // scale > 1.0 일 때만 panEnabled = true 로 설정해 드래그-투-디스미스와 충돌 방지.
+  final TransformationController _transformationController =
+      TransformationController();
+  bool _panEnabled = false;
+
+  static const double _dismissThreshold = 100;
+  static const double _velocityThreshold = 500;
+
+  @override
+  void initState() {
+    super.initState();
+    _animationController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 200),
+    );
+    _animation = Tween<double>(begin: 0, end: 0).animate(
+      CurvedAnimation(parent: _animationController, curve: Curves.easeOut),
+    );
+    _animationController.addListener(() {
+      setState(() {
+        _dragOffset = _animation.value;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    _transformationController.dispose();
+    super.dispose();
+  }
+
+  void _onInteractionUpdate(ScaleUpdateDetails details) {
+    // panEnabled 분기에 필요한 건 (scale > 1.0) boolean 전환 시점뿐이므로,
+    // scale 값 자체가 아니라 boolean 이 직전 값과 달라질 때만 setState 하여
+    // 줌 중 build/CachedNetworkImage 의 불필요한 리빌드를 줄인다.
+    final panEnabled =
+        _transformationController.value.getMaxScaleOnAxis() > 1.0;
+    if (panEnabled != _panEnabled) {
+      setState(() {
+        _panEnabled = panEnabled;
+      });
+    }
+  }
+
+  void _onVerticalDragUpdate(DragUpdateDetails details) {
+    setState(() {
+      _dragOffset += details.delta.dy;
+    });
+  }
+
+  void _onVerticalDragEnd(DragEndDetails details) {
+    _dragVelocity = details.velocity.pixelsPerSecond.dy;
+
+    final shouldDismiss = _dragOffset.abs() > _dismissThreshold ||
+        _dragVelocity.abs() > _velocityThreshold;
+
+    if (shouldDismiss) {
+      Navigator.of(context).pop();
+    } else {
+      // Snap back to center
+      _animation = Tween<double>(begin: _dragOffset, end: 0).animate(
+        CurvedAnimation(parent: _animationController, curve: Curves.easeOut),
+      );
+      _animationController.forward(from: 0);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final opacity = (1 - (_dragOffset.abs() / 300)).clamp(0.3, 1.0);
+    final scale = (1 - (_dragOffset.abs() / 1000)).clamp(0.8, 1.0);
+
+    return Scaffold(
+      backgroundColor: Colors.black.withValues(alpha: opacity),
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        iconTheme: IconThemeData(color: Colors.white.withValues(alpha: opacity)),
+        elevation: 0,
+        actions: [
+          if (widget.onSaveToGallery != null)
+            IconButton(
+              icon: Icon(Icons.download_rounded,
+                  color: Colors.white.withValues(alpha: opacity)),
+              tooltip: AppLocalizations.of(context)!.chatSaveToGallery,
+              onPressed: widget.onSaveToGallery,
+            ),
+        ],
+      ),
+      extendBodyBehindAppBar: true,
+      body: GestureDetector(
+        onVerticalDragUpdate: _onVerticalDragUpdate,
+        onVerticalDragEnd: _onVerticalDragEnd,
+        onTap: () => Navigator.of(context).pop(),
+        child: Container(
+          color: Colors.transparent,
+          child: Center(
+            child: Transform.translate(
+              offset: Offset(0, _dragOffset),
+              child: Transform.scale(
+                scale: scale,
+                child: InteractiveViewer(
+                  // scale == 1.0 일 때 pan 을 비활성화하여 드래그-투-디스미스 제스처가 동작하도록 함.
+                  // zoom 상태에서는 pan 활성화하여 정상 이동 가능.
+                  panEnabled: _panEnabled,
+                  transformationController: _transformationController,
+                  onInteractionUpdate: _onInteractionUpdate,
+                  minScale: 0.5,
+                  maxScale: 4,
+                  child: Builder(
+                    builder: (context) {
+                      final image = CachedNetworkImage(
+                        imageUrl: widget.imageUrl,
+                        fit: BoxFit.contain,
+                        placeholder: (context, url) => const Center(
+                          child: CircularProgressIndicator(
+                            color: Colors.white,
+                          ),
+                        ),
+                        errorWidget: (context, url, error) => const Center(
+                          child: Icon(Icons.broken_image, color: Colors.white54, size: 80),
+                        ),
+                      );
+                      if (widget.heroTag != null) {
+                        return Hero(tag: widget.heroTag!, child: image);
+                      }
+                      return image;
+                    },
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/chat/widgets/message_bubble/forward_room_picker_dialog.dart
+++ b/lib/presentation/pages/chat/widgets/message_bubble/forward_room_picker_dialog.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../../../../core/theme/app_colors.dart';
+import '../../../../../l10n/app_localizations.dart';
+import '../../../../../domain/entities/chat_room.dart';
+import '../../../../blocs/chat/chat_list_bloc.dart';
+import '../../../../blocs/chat/chat_list_state.dart';
+
+/// Dialog for selecting a chat room to forward a message to.
+class ForwardRoomPickerDialog extends StatefulWidget {
+  final ValueChanged<int> onRoomSelected;
+
+  const ForwardRoomPickerDialog({super.key, required this.onRoomSelected});
+
+  @override
+  State<ForwardRoomPickerDialog> createState() => _ForwardRoomPickerDialogState();
+}
+
+class _ForwardRoomPickerDialogState extends State<ForwardRoomPickerDialog> {
+  String _searchQuery = '';
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(AppLocalizations.of(context)!.chatSelectRoom),
+      content: SizedBox(
+        width: double.maxFinite,
+        height: 400,
+        child: Column(
+          children: [
+            TextField(
+              decoration: InputDecoration(
+                hintText: AppLocalizations.of(context)!.chatSearchHint,
+                prefixIcon: const Icon(Icons.search),
+                border: OutlineInputBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                contentPadding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              ),
+              onChanged: (value) => setState(() => _searchQuery = value.toLowerCase()),
+            ),
+            const SizedBox(height: 12),
+            Expanded(
+              child: BlocBuilder<ChatListBloc, ChatListState>(
+                builder: (context, state) {
+                  final rooms = state.chatRooms.where((room) {
+                    if (_searchQuery.isEmpty) return true;
+                    final name = room.displayName.toLowerCase();
+                    return name.contains(_searchQuery);
+                  }).toList();
+
+                  if (rooms.isEmpty) {
+                    return Center(child: Text(AppLocalizations.of(context)!.chatRoomListEmpty));
+                  }
+
+                  return ListView.builder(
+                    itemCount: rooms.length,
+                    itemBuilder: (context, index) {
+                      final room = rooms[index];
+                      return ListTile(
+                        leading: CircleAvatar(
+                          backgroundColor: AppColors.primaryLight,
+                          child: Icon(
+                            room.type == ChatRoomType.group
+                                ? Icons.group
+                                : Icons.person,
+                            color: Colors.white,
+                            size: 20,
+                          ),
+                        ),
+                        title: Text(
+                          room.displayName,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        onTap: () {
+                          Navigator.pop(context);
+                          widget.onRoomSelected(room.id);
+                        },
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: Text(AppLocalizations.of(context)!.commonCancel),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/pages/chat/widgets/message_bubble/message_bubble_parts.dart
+++ b/lib/presentation/pages/chat/widgets/message_bubble/message_bubble_parts.dart
@@ -1,0 +1,418 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../../../../core/theme/app_colors.dart';
+import '../../../../../l10n/app_localizations.dart';
+import '../../../../../domain/entities/message.dart';
+import '../../../../blocs/chat/chat_room_bloc.dart';
+import '../../../../blocs/chat/chat_room_event.dart';
+import 'message_file_format.dart';
+import '../video_player_page.dart';
+
+/// Centered system message (e.g. join/leave notices).
+class SystemMessageBubble extends StatelessWidget {
+  final Message message;
+
+  const SystemMessageBubble({super.key, required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Center(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          decoration: BoxDecoration(
+            color: context.dividerColor,
+            borderRadius: BorderRadius.circular(16),
+          ),
+          child: Text(
+            message.content,
+            style: TextStyle(
+              color: context.textSecondaryColor,
+              fontSize: 13,
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Failed-send status row with retry and delete buttons.
+class FailedStatusWidget extends StatelessWidget {
+  final Message message;
+
+  const FailedStatusWidget({super.key, required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // 전송 실패 아이콘
+        Icon(
+          Icons.error_outline,
+          size: 14,
+          color: Colors.red[400],
+        ),
+        const SizedBox(width: 4),
+        // 재전송 버튼
+        GestureDetector(
+          onTap: () {
+            if (message.localId != null) {
+              context.read<ChatRoomBloc>().add(MessageRetryRequested(message.localId!));
+            }
+          },
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: BoxDecoration(
+              color: AppColors.primary.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              AppLocalizations.of(context)!.chatResend,
+              style: const TextStyle(
+                color: AppColors.primary,
+                fontSize: 11,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(width: 4),
+        // 삭제 버튼
+        GestureDetector(
+          onTap: () {
+            if (message.localId != null) {
+              context.read<ChatRoomBloc>().add(PendingMessageDeleteRequested(message.localId!));
+            }
+          },
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: BoxDecoration(
+              color: Colors.red.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              AppLocalizations.of(context)!.commonDelete,
+              style: TextStyle(
+                color: Colors.red[400],
+                fontSize: 11,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// "Forwarded" indicator shown above a forwarded message.
+class ForwardedIndicator extends StatelessWidget {
+  final Message message;
+  final bool isMe;
+
+  const ForwardedIndicator({super.key, required this.message, required this.isMe});
+
+  @override
+  Widget build(BuildContext context) {
+    if (message.forwardedFromMessageId == null) return const SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            Icons.forward,
+            size: 12,
+            color: isMe ? Colors.white.withValues(alpha: 0.6) : context.textSecondaryColor,
+          ),
+          const SizedBox(width: 4),
+          Text(
+            AppLocalizations.of(context)!.chatForwarded,
+            style: TextStyle(
+              fontSize: 11,
+              fontStyle: FontStyle.italic,
+              color: isMe ? Colors.white.withValues(alpha: 0.6) : context.textSecondaryColor,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Reply/quote preview shown above the message content.
+class ReplyPreview extends StatelessWidget {
+  final Message message;
+  final bool isMe;
+
+  const ReplyPreview({super.key, required this.message, required this.isMe});
+
+  @override
+  Widget build(BuildContext context) {
+    if (message.replyToMessageId == null) return const SizedBox.shrink();
+
+    // Try the embedded replyToMessage first, then look up from BLoC state
+    final replyMsg = message.replyToMessage ??
+        context.read<ChatRoomBloc>().state.messages
+            .where((m) => m.id == message.replyToMessageId)
+            .firstOrNull;
+
+    final l10n = AppLocalizations.of(context)!;
+    final previewText = replyMsg?.isDeleted == true
+        ? l10n.chatDeletedMessage
+        : (replyMsg?.content ?? l10n.chatOriginalMessageNotFound);
+    final senderName = replyMsg?.senderNickname ?? l10n.chatUnknownSender;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 4),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      constraints: BoxConstraints(
+        maxWidth: MediaQuery.of(context).size.width * 0.55,
+      ),
+      decoration: BoxDecoration(
+        color: isMe
+            ? Colors.white.withValues(alpha: 0.15)
+            : AppColors.primary.withValues(alpha: 0.08),
+        borderRadius: BorderRadius.circular(8),
+        border: Border(
+          left: BorderSide(
+            color: isMe ? Colors.white.withValues(alpha: 0.5) : AppColors.primary,
+            width: 2,
+          ),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            senderName,
+            style: TextStyle(
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+              color: isMe ? Colors.white.withValues(alpha: 0.9) : AppColors.primary,
+            ),
+          ),
+          Text(
+            previewText,
+            style: TextStyle(
+              fontSize: 12,
+              color: isMe
+                  ? Colors.white.withValues(alpha: 0.7)
+                  : context.textSecondaryColor,
+            ),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Video message bubble with thumbnail + play overlay.
+class VideoBubble extends StatelessWidget {
+  final Message message;
+  final bool isMe;
+
+  const VideoBubble({super.key, required this.message, required this.isMe});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (_) => VideoPlayerPage(
+              videoUrl: message.fileUrl!,
+              title: message.fileName,
+            ),
+          ),
+        );
+      },
+      child: ClipRRect(
+        borderRadius: BorderRadius.only(
+          topLeft: const Radius.circular(18),
+          topRight: const Radius.circular(18),
+          bottomLeft: Radius.circular(isMe ? 18 : 4),
+          bottomRight: Radius.circular(isMe ? 4 : 18),
+        ),
+        child: Container(
+          constraints: BoxConstraints(
+            maxWidth: MediaQuery.of(context).size.width * 0.65,
+          ),
+          width: 200,
+          height: 150,
+          color: Colors.black87,
+          child: Stack(
+            alignment: Alignment.center,
+            children: [
+              if (message.thumbnailUrl != null)
+                Image.network(
+                  message.thumbnailUrl!,
+                  fit: BoxFit.cover,
+                  width: double.infinity,
+                  height: double.infinity,
+                  errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                ),
+              Container(
+                decoration: BoxDecoration(
+                  color: Colors.black.withValues(alpha: 0.3),
+                  shape: BoxShape.circle,
+                ),
+                padding: const EdgeInsets.all(12),
+                child: const Icon(
+                  Icons.play_arrow,
+                  color: Colors.white,
+                  size: 32,
+                ),
+              ),
+              // File name and size at the bottom
+              Positioned(
+                bottom: 8,
+                left: 8,
+                right: 8,
+                child: Row(
+                  children: [
+                    const Icon(Icons.videocam, color: Colors.white70, size: 14),
+                    const SizedBox(width: 4),
+                    Expanded(
+                      child: Text(
+                        message.fileName ?? AppLocalizations.of(context)!.chatVideo,
+                        style: const TextStyle(
+                          color: Colors.white70,
+                          fontSize: 11,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// File message bubble (icon + name + size).
+class FileBubble extends StatelessWidget {
+  final Message message;
+  final bool isMe;
+  final VoidCallback onTap;
+  final VoidCallback onLongPress;
+
+  const FileBubble({
+    super.key,
+    required this.message,
+    required this.isMe,
+    required this.onTap,
+    required this.onLongPress,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      onLongPress: onLongPress,
+      child: Container(
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.of(context).size.width * 0.65,
+        ),
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          color: isMe ? context.myMessageBubbleColor : context.otherMessageBubbleColor,
+          borderRadius: BorderRadius.only(
+            topLeft: const Radius.circular(18),
+            topRight: const Radius.circular(18),
+            bottomLeft: Radius.circular(isMe ? 18 : 4),
+            bottomRight: Radius.circular(isMe ? 4 : 18),
+          ),
+          boxShadow: isMe
+              ? [
+                  BoxShadow(
+                    color: AppColors.primary.withValues(alpha: 0.15),
+                    blurRadius: 4,
+                    offset: const Offset(0, 2),
+                  ),
+                ]
+              : [
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.03),
+                    blurRadius: 2,
+                    offset: const Offset(0, 1),
+                  ),
+                ],
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                color: isMe
+                    ? Colors.white.withValues(alpha: 0.2)
+                    : AppColors.primary.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Icon(
+                fileIconForContentType(message.fileContentType),
+                color: isMe ? Colors.white : AppColors.primary,
+                size: 24,
+              ),
+            ),
+            const SizedBox(width: 12),
+            Flexible(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    message.fileName ?? AppLocalizations.of(context)!.chatFileFallback,
+                    style: TextStyle(
+                      color: isMe ? Colors.white : context.textPrimaryColor,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                    ),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (message.fileSize != null)
+                        Text(
+                          formatFileSize(message.fileSize!),
+                          style: TextStyle(
+                            color: isMe
+                                ? Colors.white.withValues(alpha: 0.7)
+                                : context.textSecondaryColor,
+                            fontSize: 12,
+                          ),
+                        ),
+                      const SizedBox(width: 8),
+                      Icon(
+                        Icons.download,
+                        size: 14,
+                        color: isMe
+                            ? Colors.white.withValues(alpha: 0.7)
+                            : context.textSecondaryColor,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/chat/widgets/message_bubble/message_file_format.dart
+++ b/lib/presentation/pages/chat/widgets/message_bubble/message_file_format.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+/// Returns an appropriate icon for the given file content type.
+IconData fileIconForContentType(String? contentType) {
+  if (contentType == null) return Icons.insert_drive_file;
+  if (contentType.startsWith('image/')) return Icons.image;
+  if (contentType.startsWith('video/')) return Icons.videocam;
+  if (contentType.startsWith('audio/')) return Icons.audiotrack;
+  if (contentType.contains('pdf')) return Icons.picture_as_pdf;
+  if (contentType.contains('word') || contentType.contains('document')) {
+    return Icons.description;
+  }
+  if (contentType.contains('sheet') || contentType.contains('excel')) {
+    return Icons.table_chart;
+  }
+  if (contentType.contains('presentation') || contentType.contains('powerpoint')) {
+    return Icons.slideshow;
+  }
+  if (contentType.contains('zip') || contentType.contains('rar') || contentType.contains('tar')) {
+    return Icons.folder_zip;
+  }
+  return Icons.insert_drive_file;
+}
+
+/// Formats a byte count into a human readable string (B / KB / MB / GB).
+String formatFileSize(int bytes) {
+  if (bytes < 1024) return '$bytes B';
+  if (bytes < 1024 * 1024) return '${(bytes / 1024).toStringAsFixed(1)} KB';
+  if (bytes < 1024 * 1024 * 1024) {
+    return '${(bytes / (1024 * 1024)).toStringAsFixed(1)} MB';
+  }
+  return '${(bytes / (1024 * 1024 * 1024)).toStringAsFixed(1)} GB';
+}


### PR DESCRIPTION
## 개요
Flutter 유지보수성 + 정확성 폴리시. 각 항목은 논리적 커밋 1개이며, 분할(M4a/M4b)은 **동작 보존(behavior-preserving)** 입니다. `flutter analyze`는 0 issues, `flutter test`는 전부 통과(1790 passed, ~2 skipped) 상태를 처음부터 끝까지 유지했습니다.

## 항목
### M4a — `message_bubble.dart` god file 분할 (1669 → 887줄)
content-type별 위젯을 `widgets/message_bubble/` 폴더로 추출, `message_bubble.dart`는 thin dispatcher.
| 파일 | 줄수 |
|---|---|
| message_bubble.dart (dispatcher) | 887 (was 1669) |
| message_bubble/message_bubble_parts.dart | 418 |
| message_bubble/auto_download_image_widget.dart | 176 |
| message_bubble/dismissible_image_viewer.dart | 167 |
| message_bubble/forward_room_picker_dialog.dart | 97 |
| message_bubble/message_file_format.dart | 33 |

렌더링·AppLocalizations 조회 그대로 보존. **golden(`message_bubble_list.png`) regen 없이 통과** — 위젯 트리/픽셀 불변.

### M4b — `chat_room_bloc.dart` 축소 (1516 → 1468줄)
- `ReactionHandler`: 리액션 추가/제거/수신의 cache 동기화 → optimistic mutation → WS 전송 흐름 추출 (emit/state는 bloc 보유).
- `ReadReceiptCalculator`: 읽음 이벤트 unreadCount 계산/dedup-key/처리이벤트 캡(500→250)의 순수 계산 추출.
- **의도적으로 남김**: gap-recovery/foreground 플래그 합주(`_expectPairedReconnect`, `_pendingForegrounded`, `_gapRecoveryInFlight`)는 state/emit/isClosed/타이머와 깊게 얽혀 추출 시 타이밍 동작이 바뀔 위험이 커 안전하게 둠.

### M2 — 라이프사이클 옵저버 책임 경계 명문화
조사 결과 split은 설계상 올바름: presence는 per-room(active/inactive 모두 roomId 인자)이고, 방 밖(채팅 목록)에는 active 방이 없어 백그라운드 전환 시 누락되는 presence 의무가 없음. `app.dart`(전역 보안잠금)와 `chat_room_page`(per-room presence/socket)에 경계 주석 추가. 동작 변경 없음.

### M3 — 백그라운드 FCM data-only 푸시 robust화
`firebaseMessagingBackgroundHandler`: notification 블록 있으면 OS 자동표시 → 중복 방지 즉시 종료. data-only면 별도 isolate에서 `FlutterLocalNotificationsPlugin` 생성해 로컬 알림 직접 표시(채널 `chat_messages` 일치, payload `chatRoom:id`).

### L1 — WS 재연결 토큰 갱신을 single-flight로 통합
WS의 throwaway Dio refresh가 `auth_interceptor`의 single-flight와 경쟁(rotation race)하던 문제 → `AuthInterceptor.refreshTokenForReconnect()`(= `_ensureRefreshed` 공유)로 위임. delegate 미주입 시 기존 Dio fallback 유지.

### L2 — STOMP 인증 오류 감지 구조화/중앙화
`_isAuthError()`로 중앙화: STOMP ERROR 프레임 헤더(status/code 401/403) 우선, 텍스트(message 헤더+본문)는 fallback. 기존 매칭 케이스 superset.

### L3 — 빈 catch 블록 가시화
조용히 삼키던 `catch(_) {}` 5곳에 `kDebugMode` debugPrint 추가(릴리스 무음 유지): chat_room_page(2), fcm_service, notification_click_handler, desktop_notification_bridge.

### L4 — iOS push 문서/코드 불일치 정정
**코드 진실**: iOS 푸시는 완전히 wired. `main.dart`/`di/injection.dart`(iOS→mobile env→FcmServiceImpl)/`auth_bloc.dart`의 `Platform.isIOS` 분기 + `AppDelegate.swift`(`registerForRemoteNotifications`, `Messaging.messaging().apnsToken`) + `Runner.entitlements`(aps-environment: production) + `Info.plist`(UIBackgroundModes: remote-notification). fcm_service.dart의 stale "Android 전용/TODO iOS 활성화 필요" 주석을 실제 상태로 정정(CLAUDE.md는 정확하므로 유지).

## Behavior-preserving 노트
M4a/M4b는 순수 구조 분할이며 동작/이벤트 의미를 바꾸지 않습니다. golden 재생성 없이 통과했고 기존 1790 테스트가 그대로 녹색입니다.

## Verify
- `flutter analyze` → **No issues found!**
- `flutter test` → **All tests passed (1790 passed)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)