### PR TITLE
fix: i18n 잔여 하드코딩·취약한 문자열 매칭·stale 주석 정리 (A− → A)

### DIFF
--- a/lib/core/utils/error_message_mapper.dart
+++ b/lib/core/utils/error_message_mapper.dart
@@ -3,6 +3,27 @@ import '../errors/exceptions.dart';
 
 /// Exception을 사용자 친화적인 메시지로 변환하는 유틸리티
 class ErrorMessageMapper {
+  /// 매핑되지 않은(알 수 없는) 에러의 기본 메시지.
+  /// 단일 소스로 유지해 호출부가 문자열을 하드코딩하지 않도록 한다.
+  static const String unknownErrorMessage =
+      '알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+
+  /// 인식된 예외 타입 중 어느 것에도 해당하지 않아
+  /// [unknownErrorMessage] 폴백으로 떨어지는 "알 수 없는 오류"인지 여부.
+  ///
+  /// 호출부가 사용자 표시용 메시지를 `contains('알 수 없는 오류')`로
+  /// 부분 문자열 매칭하던 취약한 방식을 대체한다(타입 기반 판별).
+  static bool isUnknownError(dynamic error) {
+    return error is! AuthException &&
+        error is! ServerException &&
+        error is! NetworkException &&
+        error is! CacheException &&
+        error is! ValidationException &&
+        error is! ConflictException &&
+        error is! PasswordMismatchException &&
+        error is! PlatformException;
+  }
+
   /// Exception을 사용자 친화적인 메시지로 변환
   static String toUserFriendlyMessage(dynamic error) {
     if (error is AuthException) {
@@ -38,7 +59,7 @@ class ErrorMessageMapper {
     }
 
     // 알 수 없는 에러의 경우
-    return '알 수 없는 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+    return unknownErrorMessage;
   }
   
   static String _getAuthErrorMessage(AuthException error) {

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -76,6 +76,7 @@
   "chatFileFallback": "File",
   "chatLinkFallback": "Link",
   "chatDeletedMessage": "Deleted message",
+  "chatDeletedMessageBubble": "This message was deleted",
   "chatOriginalMessageNotFound": "Original message not found",
   "chatUnknownSender": "Unknown",
   "chatForwarded": "Forwarded",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -121,6 +121,7 @@
   "chatFileFallback": "파일",
   "chatLinkFallback": "링크",
   "chatDeletedMessage": "삭제된 메시지",
+  "chatDeletedMessageBubble": "삭제된 메시지입니다",
   "chatOriginalMessageNotFound": "원본 메시지를 찾을 수 없습니다",
   "chatUnknownSender": "알 수 없음",
   "chatForwarded": "전달됨",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -554,6 +554,12 @@ abstract class AppLocalizations {
   /// **'삭제된 메시지'**
   String get chatDeletedMessage;
 
+  /// No description provided for @chatDeletedMessageBubble.
+  ///
+  /// In ko, this message translates to:
+  /// **'삭제된 메시지입니다'**
+  String get chatDeletedMessageBubble;
+
   /// No description provided for @chatOriginalMessageNotFound.
   ///
   /// In ko, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -256,6 +256,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get chatDeletedMessage => 'Deleted message';
 
   @override
+  String get chatDeletedMessageBubble => 'This message was deleted';
+
+  @override
   String get chatOriginalMessageNotFound => 'Original message not found';
 
   @override

--- a/lib/l10n/app_localizations_ko.dart
+++ b/lib/l10n/app_localizations_ko.dart
@@ -250,6 +250,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get chatDeletedMessage => '삭제된 메시지';
 
   @override
+  String get chatDeletedMessageBubble => '삭제된 메시지입니다';
+
+  @override
   String get chatOriginalMessageNotFound => '원본 메시지를 찾을 수 없습니다';
 
   @override

--- a/lib/presentation/blocs/auth/auth_bloc.dart
+++ b/lib/presentation/blocs/auth/auth_bloc.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
+import '../../../core/errors/exceptions.dart';
 import '../../../core/network/websocket_service.dart';
 import '../../../core/services/desktop_notification_bridge.dart';
 import '../../../core/utils/error_message_mapper.dart';
@@ -109,7 +110,11 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
         debugPrint('[AuthBloc] Stack trace: $stackTrace');
       }
       final message = ErrorMessageMapper.toUserFriendlyMessage(e);
-      emit(AuthState.failure(message));
+      // 이메일 미인증 등 후속 분기를 위해 구조적 에러 타입을 함께 전달한다.
+      emit(AuthState.failure(
+        message,
+        errorType: e is AuthException ? e.type : null,
+      ));
     }
   }
 

--- a/lib/presentation/blocs/auth/auth_state.dart
+++ b/lib/presentation/blocs/auth/auth_state.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import '../../../core/errors/exceptions.dart';
 import '../../../domain/entities/user.dart';
 
 enum AuthStatus {
@@ -16,11 +17,16 @@ class AuthState extends Equatable {
   final String? errorMessage;
   final String? signupEmail;
 
+  /// 실패 상태일 때의 인증 에러 타입(구조적 신호).
+  /// UI가 표시 메시지를 부분 문자열 매칭하는 대신 이 타입으로 분기한다.
+  final AuthErrorType? authErrorType;
+
   const AuthState({
     this.status = AuthStatus.initial,
     this.user,
     this.errorMessage,
     this.signupEmail,
+    this.authErrorType,
   });
 
   const AuthState.initial() : this(status: AuthStatus.initial);
@@ -35,23 +41,31 @@ class AuthState extends Equatable {
   const AuthState.signUpSuccess(String email)
       : this(status: AuthStatus.signUpSuccess, signupEmail: email);
 
-  const AuthState.failure(String message, {User? user})
-      : this(status: AuthStatus.failure, errorMessage: message, user: user);
+  const AuthState.failure(String message, {User? user, AuthErrorType? errorType})
+      : this(
+          status: AuthStatus.failure,
+          errorMessage: message,
+          user: user,
+          authErrorType: errorType,
+        );
 
   AuthState copyWith({
     AuthStatus? status,
     User? user,
     String? errorMessage,
     String? signupEmail,
+    AuthErrorType? authErrorType,
   }) {
     return AuthState(
       status: status ?? this.status,
       user: user ?? this.user,
       errorMessage: errorMessage ?? this.errorMessage,
       signupEmail: signupEmail ?? this.signupEmail,
+      authErrorType: authErrorType ?? this.authErrorType,
     );
   }
 
   @override
-  List<Object?> get props => [status, user, errorMessage, signupEmail];
+  List<Object?> get props =>
+      [status, user, errorMessage, signupEmail, authErrorType];
 }

--- a/lib/presentation/blocs/chat/managers/message_cache_manager.dart
+++ b/lib/presentation/blocs/chat/managers/message_cache_manager.dart
@@ -389,15 +389,19 @@ class MessageCacheManager {
   ///    로컬 메시지를 정확히 교체한다. 동일 내용("ㅇㅇ" 등) 메시지가 여러 개
   ///    pending 상태여도 올바른 버블을 교체한다.
   /// 2) FALLBACK by content + 시간 window: echo에 clientMessageId가 없을 때만
-  ///    (백엔드 미지원) 기존 방식으로 매칭한다.
+  ///    (예: 구버전 서버) 기존 방식으로 매칭한다.
   ///    - Locally originated (negative ID)
   ///    - Same content
   ///    - Created within 60 seconds of the real message
   ///    - If multiple matches, select the OLDEST one (FIFO)
   ///
-  /// NOTE(backend): 정확 매칭을 위해 백엔드가 broadcast/echo 메시지에
-  /// `clientMessageId`를 그대로 되돌려줘야 한다 (백엔드 PR 예정). 그 전까지는
-  /// fallback이 동작하므로 무회귀(no-regression) 개선이다.
+  /// NOTE(backend): 백엔드가 broadcast/echo 메시지에 `clientMessageId`를
+  /// 그대로 되돌려주는 동작이 적용되어, 현재 정확(exact) 매칭이 활성화되어 있다.
+  /// (수신/파싱 경로: websocket_events.dart에서 `json['clientMessageId']`를 파싱 →
+  /// websocket_subscription_manager.dart에서 Message.localId 슬롯에 매핑 →
+  /// 본 메서드의 1) 단계에서 localId 정확 매칭에 사용.)
+  /// echo에 clientMessageId가 없는 경우(예: 구버전 서버)에는 2) content+window
+  /// fallback이 계속 동작한다.
   bool replacePendingMessageWithReal(String content, Message realMessage) {
     final maxTimeDiff = const Duration(seconds: 60);
     int? localIndex;

--- a/lib/presentation/blocs/settings/account_deletion_bloc.dart
+++ b/lib/presentation/blocs/settings/account_deletion_bloc.dart
@@ -87,12 +87,12 @@ class AccountDeletionBloc extends Bloc<AccountDeletionEvent, AccountDeletionStat
         return true;
       }());
 
-      final message = ErrorMessageMapper.toUserFriendlyMessage(e);
-      // 에러 메시지가 너무 일반적인 경우 더 구체적인 메시지 제공
-      if (message.contains('알 수 없는 오류')) {
+      // 인식되지 않은(알 수 없는) 에러면 더 구체적인 안내로 대체한다.
+      // 사용자 표시 메시지의 부분 문자열 매칭 대신 타입 기반으로 판별한다.
+      if (ErrorMessageMapper.isUnknownError(e)) {
         emit(AccountDeletionState.error('회원 탈퇴 처리 중 오류가 발생했습니다. 비밀번호를 확인해주세요.'));
       } else {
-        emit(AccountDeletionState.error(message));
+        emit(AccountDeletionState.error(ErrorMessageMapper.toUserFriendlyMessage(e)));
       }
     }
   }

--- a/lib/presentation/blocs/settings/change_password_bloc.dart
+++ b/lib/presentation/blocs/settings/change_password_bloc.dart
@@ -29,11 +29,12 @@ class ChangePasswordBloc extends Bloc<ChangePasswordEvent, ChangePasswordState> 
       );
       emit(const ChangePasswordState.success());
     } catch (e) {
-      final message = ErrorMessageMapper.toUserFriendlyMessage(e);
-      if (message.contains('알 수 없는 오류')) {
+      // 인식되지 않은(알 수 없는) 에러면 도메인 특화 안내로 대체한다.
+      // 사용자 표시 메시지의 부분 문자열 매칭 대신 타입 기반으로 판별한다.
+      if (ErrorMessageMapper.isUnknownError(e)) {
         emit(ChangePasswordState.error('비밀번호 변경에 실패했습니다. 현재 비밀번호를 확인해주세요.'));
       } else {
-        emit(ChangePasswordState.error(message));
+        emit(ChangePasswordState.error(ErrorMessageMapper.toUserFriendlyMessage(e)));
       }
     }
   }

--- a/lib/presentation/pages/auth/login_page.dart
+++ b/lib/presentation/pages/auth/login_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
+import '../../../core/errors/exceptions.dart';
 import '../../../core/router/app_router.dart';
 import '../../../core/theme/app_colors.dart';
 import '../../../core/utils/validators.dart';
@@ -65,8 +66,7 @@ class _LoginPageState extends State<LoginPage> {
           if (state.status == AuthStatus.authenticated) {
             context.go(AppRoutes.friends);
           } else if (state.status == AuthStatus.failure) {
-            if (state.errorMessage != null &&
-                state.errorMessage!.contains('이메일 인증')) {
+            if (state.authErrorType == AuthErrorType.emailNotVerified) {
               // 이메일 인증 페이지로 이동
               context.go(
                 '${AppRoutes.emailVerification}?email=${Uri.encodeComponent(_emailController.text.trim())}',

--- a/lib/presentation/pages/chat/widgets/message_bubble.dart
+++ b/lib/presentation/pages/chat/widgets/message_bubble.dart
@@ -710,8 +710,14 @@ class MessageBubble extends StatelessWidget {
     // Text message (default)
     final textColor = isMe ? Colors.white : context.textPrimaryColor;
 
+    // 삭제된 메시지는 본문 대신 l10n 플레이스홀더를 렌더링한다.
+    // (도메인 엔티티의 displayContent 폴백을 거치지 않고 직접 현지화한다.)
+    final displayText = message.isDeleted
+        ? AppLocalizations.of(context)!.chatDeletedMessageBubble
+        : message.displayContent;
+
     // URL detection (show preview for first URL only)
-    final urlMatches = urlPattern.allMatches(message.displayContent);
+    final urlMatches = urlPattern.allMatches(displayText);
     final firstUrlRaw = urlMatches.isNotEmpty ? urlMatches.first.group(0) : null;
     final firstUrl = firstUrlRaw != null ? normalizeUrl(firstUrlRaw) : null;
 
@@ -752,7 +758,7 @@ class MessageBubble extends StatelessWidget {
           ReplyPreview(message: message, isMe: isMe),
           RichText(
             text: TextSpan(
-              children: _buildTextSpans(context, message.displayContent, textColor),
+              children: _buildTextSpans(context, displayText, textColor),
             ),
           ),
           // Link preview

--- a/test/blocs/auth_event_state_test.dart
+++ b/test/blocs/auth_event_state_test.dart
@@ -183,7 +183,7 @@ void main() {
         errorMessage: 'Error',
       );
 
-      expect(state.props.length, 4);
+      expect(state.props.length, 5);
     });
   });
 


### PR DESCRIPTION
## 개요
재감사(grade A−)에서 발견된 잔여 항목을 동작 보존(behavior-preserving)으로 정리합니다. 한국어 표시 문자열은 모두 기존과 동일합니다.

## 변경 사항

### 1. i18n 잔여 누수
- 메시지 버블의 삭제된 메시지 본문이 `AppLocalizations`를 우회하고 `'삭제된 메시지입니다'` 리터럴로 직접 렌더링되던 문제를 수정했습니다.
- `chatDeletedMessageBubble` ARB 키 추가(`app_ko.arb` / `app_en.arb`). 한국어는 기존 표시 문자열과 **동일**하게 유지(`삭제된 메시지입니다`).
- 도메인 `Message.displayContent`는 폴백으로 유지(기존 단위 테스트 계약 보존).
- 추가 스윕 결과, 위젯 계층의 다른 사용자 노출 하드코딩 한글은 없음. BLoC 계층 메시지 문자열은 기존 아키텍처(컨텍스트 비의존)로 의도적으로 유지, 약관/개인정보 페이지는 정적 법률 문서로 유지.

### 2. 취약한 문자열 매칭 2곳 → 구조적 신호
- `'알 수 없는 오류'` 부분 문자열 매칭(`change_password_bloc`, `account_deletion_bloc`) → `ErrorMessageMapper.isUnknownError(e)` 타입 기반 판별로 대체. 폴백 문자열은 상수로 단일화.
- `'이메일 인증'` 부분 문자열 매칭(`login_page`) → `AuthState.authErrorType`(`AuthErrorType`) 구조적 필드 추가, `AuthErrorType.emailNotVerified`로 분기.

### 3. stale 주석 수정
- `message_cache_manager.dart`의 "백엔드 PR 예정/미지원" 주석을 제거. 백엔드 echo가 적용되어 `clientMessageId` 정확(exact) 매칭이 활성화되어 있음을 종단간(parse → localId 매핑 → 매칭) 검증 후 반영.

## 검증
- `flutter analyze` → **No issues found!**
- `flutter test` → **All tests passed!** (1790 passed, 2 skipped). 골든 재생성 불필요(삭제 메시지 글리프 동일, 골든은 비삭제 메시지만 렌더).

동작 보존됨 — 모든 잔여 항목 종료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)